### PR TITLE
limit activation to "Network wide"

### DIFF
--- a/src/wpmn-loader.php
+++ b/src/wpmn-loader.php
@@ -23,6 +23,7 @@
  * Author:      johnjamesjacoby, ddean, BrianLayman
  * Author URI:  http://jjj.me
  * Tags:        multi, networks, site, network, blog, domain, subdomain, path, multisite, MS
+ * Network:     true
  */
 
 // Exit if accessed directly


### PR DESCRIPTION
There is no use in activating this on a single site in the network
