### PR TITLE
replace [deprecated] like_escape() with $wpdb->esc_like()

### DIFF
--- a/src/includes/class-wp-ms-networks-list-table.php
+++ b/src/includes/class-wp-ms-networks-list-table.php
@@ -38,7 +38,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 			$search_conditions = trim( $search_conditions, '*' );
 		}
 
-		$like_s = esc_sql( like_escape( $search_conditions ) );
+		$like_s = esc_sql( $wpdb->esc_like( $search_conditions ) );
 
 		$total_query = 'SELECT COUNT( id ) FROM ' . $wpdb->site . ' WHERE 1=1 ';
 		


### PR DESCRIPTION
`like_escape()` is deprecated and replaced by $wpdb->esc_like()

---

**This bumps up the required WP core version up to 4.0!!**
