### PR TITLE
Reverted the use of get_network_by_path() within add_network()

### DIFF
--- a/includes/functions-wp-ms-networks.php
+++ b/includes/functions-wp-ms-networks.php
@@ -289,7 +289,9 @@ function add_network( $args = array() ) {
 	$r['path']   = str_replace( ' ', '', strtolower( $r['path']   ) );
 
 	// Check for existing network
-	$network = get_network_by_path( $r['domain'], $r['path'] );
+	$sql     = "SELECT * FROM {$wpdb->site} WHERE domain = %s AND path = %s LIMIT 1";
+	$query   = $wpdb->prepare( $sql, $r['domain'], $r['path'] );
+	$network = $wpdb->get_row( $query );
 
 	if ( ! empty( $network ) ) {
 		return new WP_Error( 'network_exists', __( 'Network already exists.', 'wp-multi-network' ) );


### PR DESCRIPTION
 to use a custom SQL Query. Fixes #59

get_network_by_path() is used to check for the existence of a network when it is added. This will work only when the network is completely different i.e. abc.dev and xyz.com but not when the network is a subdomain - abc.xyz.com vs xyz.com