### PR TITLE
Use the network blog_id if it's set

### DIFF
--- a/includes/functions-wp-ms-networks.php
+++ b/includes/functions-wp-ms-networks.php
@@ -71,7 +71,8 @@ function get_main_site_for_network( $network = null ) {
 		return false;
 	}
 
-	if ( ! $primary_id = wp_cache_get( 'network:' . $network->id . ':main_site', 'site-options' ) ) {
+	$primary_id = isset( $network->blog_id ) ? $network->blog_id : wp_cache_get( 'network:' . $network->id . ':main_site', 'site-options' );
+	if ( ! $primary_id ) {
 		$sql        = "SELECT blog_id FROM {$wpdb->blogs} WHERE domain = %s AND path = %s";
 		$query      = $wpdb->prepare( $sql, $network->domain, $network->path );
 		$primary_id = $wpdb->get_var( $query );


### PR DESCRIPTION
The `get_main_site_for_network()` function is hard-coded to retrieve the main site from the `wp_blogs` table of the database. However, WordPress natively adds the main site to the `$current_site` global object.

This change allows the `get_main_site_for_network()` function to use the `$current_site->blog_id` value if present, with a fallback to cache and a database query if that's not present.