### PR TITLE
Improvements & fixes to `move_site()`

### DIFF
--- a/includes/functions-wp-ms-networks.php
+++ b/includes/functions-wp-ms-networks.php
@@ -619,6 +619,9 @@ function move_site( $site_id, $new_network_id ) {
 			if ( false !== ( $separator_pos = strpos( $site->domain, '.' ) ) ) {
 				$ex_dom = substr( $site->domain, 0, ( $separator_pos + 1 ) );
 				$domain = $ex_dom . $new_network->domain;
+				if ( get_blog_id_from_url( $domain ) ) {
+					return new WP_Error( 'subdomain_already_exist', __( 'Subdomain already exists in the new network.', 'wp-multi-network' ) );
+				}
 			} else {
 				$domain = $site->domain;
 			}

--- a/includes/functions-wp-ms-networks.php
+++ b/includes/functions-wp-ms-networks.php
@@ -610,6 +610,8 @@ function move_site( $site_id, $new_network_id ) {
 			return new WP_Error( 'network_not_exist', __( 'Network does not exist.', 'wp-multi-network' ) );
 		}
 
+		$path = substr( $site->path, strlen( $old_network->path ) );
+
 		// Tweak the domain and path if needed
 		// If the site domain is the same as the network domain on a subdomain
 		// install, don't prepend old "hostname"
@@ -619,7 +621,7 @@ function move_site( $site_id, $new_network_id ) {
 			if ( false !== ( $separator_pos = strpos( $site->domain, '.' ) ) ) {
 				$ex_dom = substr( $site->domain, 0, ( $separator_pos + 1 ) );
 				$domain = $ex_dom . $new_network->domain;
-				if ( get_blog_id_from_url( $domain ) ) {
+				if ( domain_exists( $domain, $path, $new_network_id ) ) {
 					return new WP_Error( 'subdomain_already_exist', __( 'Subdomain already exists in the new network.', 'wp-multi-network' ) );
 				}
 			} else {
@@ -627,8 +629,10 @@ function move_site( $site_id, $new_network_id ) {
 			}
 		} else {
 			$domain = $new_network->domain;
+			if ( domain_exists( $domain, $path, $new_network_id ) ) {
+				return new WP_Error( 'path_already_exist', __( 'Path already exists in the new network.', 'wp-multi-network' ) );
+			}
 		}
-		$path = substr( $site->path, strlen( $old_network->path ) );
 
 	// New network is zero (orphan)
 	} else {

--- a/includes/functions-wp-ms-networks.php
+++ b/includes/functions-wp-ms-networks.php
@@ -618,9 +618,15 @@ function move_site( $site_id, $new_network_id ) {
 		// Tweak the domain and path if needed
 		// If the site domain is the same as the network domain on a subdomain
 		// install, don't prepend old "hostname"
+		// If the site domain is a regular domain independent of the network's domain,
+		// keep the domain the same
 		if ( is_subdomain_install() && ( $site->domain !== $old_network->domain ) ) {
-			$ex_dom = substr( $site->domain, 0, ( strpos( $site->domain, '.' ) + 1 ) );
-			$domain = $ex_dom . $new_network->domain;
+			if ( false !== ( $separator_pos = strpos( $site->domain, '.' ) ) ) {
+				$ex_dom = substr( $site->domain, 0, ( $separator_pos + 1 ) );
+				$domain = $ex_dom . $new_network->domain;
+			} else {
+				$domain = $site->domain;
+			}
 		} else {
 			$domain = $new_network->domain;
 		}

--- a/includes/functions-wp-ms-networks.php
+++ b/includes/functions-wp-ms-networks.php
@@ -603,11 +603,6 @@ function move_site( $site_id, $new_network_id ) {
 	$old_network_id = (int) $site->site_id;
 	$old_network    = wp_get_network( $old_network_id );
 
-	// No change
-	if ( $old_network_id === $new_network_id ) {
-		return new WP_Error( 'blog_not_moved', __( 'Site was not moved.', 'wp-multi-network' ) );
-	}
-
 	// New network is not zero
 	if ( 0 !== $new_network_id ) {
 		$new_network = wp_get_network( $new_network_id );


### PR DESCRIPTION
The changes in this request address multiple issues in the `move_site()` function:

* sites with a second-level-domain (regular domain) which is independent of the network's domain are now handled correctly when moved to a different network; before this change the plugin would take the second-level domain part name and use it as a subdomain for the moved site
* if the subdomain (or path) of the site is already taken in the new network, the function will now return a `WP_Error` object; this should prevent the issue that @rmccue outlined in #48 (basically his proposed step a)
* removed a redundant check (lines 606-610) of whether the site is already on the new network; this check has been there twice before, once returning true and then again (this point was never reached) to return a `WP_Error`; so I removed the second check

If any of the changes requires some refinement before merging or is not qualified to be merged, I will gladly adjust the pull request.