### PR TITLE
Prevents fatals on WP trunk

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -28,11 +28,13 @@ function network_exists( $network_id ) {
  *
  * @return array Networks available on the installation
  */
-function get_networks() {
-	global $wpdb;
+ if ( ! function_exists( 'get_networks') ){
+	function get_networks() {
+		global $wpdb;
 
-	return $wpdb->get_results( "SELECT * FROM {$wpdb->site}" );
-}
+		return $wpdb->get_results( "SELECT * FROM {$wpdb->site}" );
+	}
+ }
 
 /**
  *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -29,7 +29,7 @@ function network_exists( $network_id ) {
  * @return array Networks available on the installation
  */
  if ( ! function_exists( 'get_networks') ){
-	function get_networks() {
+	function get_networks( $args = '' ) {
 		global $wpdb;
 
 		return $wpdb->get_results( "SELECT * FROM {$wpdb->site}" );


### PR DESCRIPTION
`get_networks` exist in core now. I didn't dig in to confirm the functions return the same way, just enough to stop the fatal.