### PR TITLE
Fix site re assignement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+### PHP Storm ###
+.idea/

--- a/includes/classes/class-wp-ms-networks-admin.php
+++ b/includes/classes/class-wp-ms-networks-admin.php
@@ -882,7 +882,33 @@ class WP_MS_Networks_Admin {
 		$sql    = "SELECT blog_id FROM {$wpdb->blogs} WHERE site_id = %d";
 		$prep   = $wpdb->prepare( $sql, $network_id );
 		$sites  = $wpdb->get_results( $prep );
-		$moving = array_filter( array_merge( $to, $from ) );
+
+		// Get site's ids list
+		$sitesList = array();
+		foreach ( $sites as $site ) {
+			$sitesList[] = $site->blog_id;
+		}
+
+		// Find sites which need to be moved into current network
+		$movingTo = [];
+		foreach ( $to as $site_id ) {
+			if ( in_array( $site_id, $sitesList ) ) {
+				continue;
+			}
+			$movingTo[] = $site_id;
+		}
+
+		// Find sites which need to be moved out from current network
+		$movingFrom = [];
+		foreach ( $from as $site_id ) {
+			if ( ! in_array( $site_id, $sitesList ) ) {
+				continue;
+			}
+			$movingFrom[] = $site_id;
+		}
+
+		// Merge into one array
+		$moving = array_filter( array_merge( $movingTo, $movingFrom ) );
 
 		// Loop through and move sites
 		foreach ( $moving as $site_id ) {
@@ -893,7 +919,7 @@ class WP_MS_Networks_Admin {
 			}
 
 			// Coming in
-			if ( in_array( $site_id, $to ) && ! in_array( $site_id, $sites ) ) {
+			if ( in_array( $site_id, $to ) && ! in_array( $site_id, $sitesList ) ) {
 				move_site( $site_id, $network_id );
 
 			// Orphaning out

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -38,6 +38,46 @@ function get_networks() {
 }
 endif;
 
+if ( ! function_exists( 'get_network_domain' ) ) :
+	/**
+	 * Get network's domain name
+	 *
+	 * @author Maxime CULEA
+	 * @since 1.7.1
+	 *
+	 * @param $network_id
+	 *
+	 * @return null|string
+	 */
+	function get_network_domain( $network_id ) {
+		global $wpdb;
+
+		return $wpdb->get_var( $wpdb->prepare( "SELECT domain FROM {$wpdb->site} WHERE id= %d", $network_id ) );
+	}
+endif;
+
+if ( ! function_exists( 'has_path_for_network' ) ) :
+	/**
+	 * Check if given path already exist in the given network (domain)
+	 *
+	 * @author Maxime CULEA
+	 * @since 1.7.1
+	 *
+	 * @param $network_id
+	 * @param $path
+	 *
+	 * @return bool
+	 */
+	function has_path_for_network( $network_id, $path ) {
+		global $wpdb;
+
+		// Check for existing network
+		$network = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->blogs} WHERE site_id = %d AND path = %s LIMIT 1", $network_id, $path ) );
+
+		return ! empty( $network );
+	}
+endif;
+
 if ( ! function_exists( 'user_has_networks' ) ) :
 /**
  *

--- a/wpmn-loader.php
+++ b/wpmn-loader.php
@@ -4,8 +4,8 @@
  * Plugin Name: WP Multi-Network
  * Plugin URI:  https://wordpress.org/plugins/wp-multi-network/
  * Description: A Network Management UI for global administrators in WordPress Multisite
- * Version:     1.8.0
- * Author:      johnjamesjacoby, ddean, BrianLayman, rmccue
+ * Version:     1.7.1
+ * Author:      johnjamesjacoby, ddean, BrianLayman, rmccue, MaximeCulea
  * Author URI:  http://jjj.me
  * Tags:        blog, domain, mapping, multisite, network, networks, path, site, subdomain
  * Network:     true


### PR DESCRIPTION
Hi @johnjamesjacoby,

I managed to clean the code for this PR : https://github.com/stuttter/wp-multi-network/pull/74
It is ready for merge under 1.7.1 tag.

I have tested this on a website which was already using 74's PR version. So re-assignement, add and take-off blog to/from site, is now wonderfully working !
I hope it's all good for you, and can't wait for your feedback :smiley:

Cheers