### PR TITLE
made admin instance publicly available (fixed #77)

### DIFF
--- a/wpmn-loader.php
+++ b/wpmn-loader.php
@@ -44,6 +44,11 @@ class WPMN_Loader {
 	public $asset_version = 201510070001;
 
 	/**
+	 * @var WP_MS_Networks_Admin|null Admin class instance
+	 */
+	public $admin = null;
+
+	/**
 	 * Load WP Multi Network
 	 *
 	 * @since 1.3
@@ -122,7 +127,7 @@ class WPMN_Loader {
 			load_plugin_textdomain( 'wp-multi-network', false, dirname( $this->basename ) . '/languages/' );
 
 			// Setup the network admin
-			new WP_MS_Networks_Admin();
+			$this->admin = new WP_MS_Networks_Admin();
 		}
 
 		// Deprecated functions & classes


### PR DESCRIPTION
This pull-request stores the admin instance in a public `$admin` member variable so that it can be accessed via `wpmn()->admin`. A check whether it's null or not is necessary since it only exists if we're in admin.