### PR TITLE
pass new network arguments to add_network action hook (fixed #79)

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -454,7 +454,7 @@ function add_network( $args = array() ) {
 		restore_current_network();
 	}
 
-	do_action( 'add_network', $new_network_id );
+	do_action( 'add_network', $new_network_id, $r );
 
 	return $new_network_id;
 }


### PR DESCRIPTION
This pull-request passes the arguments that were used to create a new network to the `add_network` action hook (see #79).