### PR TITLE
Fix multi network delete

### DIFF
--- a/includes/classes/class-wp-ms-networks-admin.php
+++ b/includes/classes/class-wp-ms-networks-admin.php
@@ -280,6 +280,7 @@ class WP_MS_Networks_Admin {
 						$this->all_networks_page();
 						break;
 				}
+				break;
 
 			// All networks
 			default:

--- a/includes/classes/class-wp-ms-networks-admin.php
+++ b/includes/classes/class-wp-ms-networks-admin.php
@@ -583,7 +583,7 @@ class WP_MS_Networks_Admin {
 
 					if ( RESCUE_ORPHANED_BLOGS ) { ?>
 
-						<div class="error">
+						<div class="error inline">
 							<h3><?php esc_html_e( 'You have selected the following networks for deletion', 'wp-multi-network' ); ?>:</h3>
 							<ul>
 								<?php foreach ( $network as $deleted_network ) : ?>
@@ -596,7 +596,7 @@ class WP_MS_Networks_Admin {
 
 					<?php } else { ?>
 
-						<div class="error">
+						<div class="error inline">
 							<h3><?php esc_html_e( 'You have selected the following networks for deletion', 'wp-multi-network' ); ?>:</h3>
 							<ul>
 								<?php foreach ( $network as $deleted_network ) : ?>
@@ -612,7 +612,7 @@ class WP_MS_Networks_Admin {
 
 				} else { ?>
 
-					<div id="message">
+					<div id="message inline">
 						<h3><?php esc_html_e( 'You have selected the following networks for deletion', 'wp-multi-network' ); ?>:</h3>
 						<ul>
 							<?php foreach ( $network as $deleted_network ) : ?>


### PR DESCRIPTION
**Fix 1**
WordPress moves error, message, and notice CSS class elements and move them to the top. From `wp-admin/js/common.js`:
```js
$( 'div.updated, div.error, div.notice' ).not( '.inline, .below-h2' ).insertAfter( $( '.wrap h1, .wrap h2' ).first() );
```

This has an unfortunate side-effect on WP Multi Network. The confirmation form element and the form element with networks-to-be-deleted is within the `error` or `message` div. In this way, deleting multiple networks using checkboxes fails.

This fix makes the `error` or `message` divs inline to prevent them from jumping outside the form element.

**Fix 2**
Ensure all networks page is not duplicated

Shown twice if
* the confirmation on multi delete is left empty and using the browser back button to get out of the error page.
* the Apply button is clicked without a dropdown action.

Side effect: Multi delete page doesn't list all networks. This is consistent with the other actions like delete single network, etc.