### PR TITLE
Fixes for network name and network admin on CLI 'create' command

### DIFF
--- a/includes/classes/class-wp-ms-networks-cli.php
+++ b/includes/classes/class-wp-ms-networks-cli.php
@@ -24,10 +24,10 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 	 * : Path for network
 	 *
 	 * --user=<id|login|email>
-	 * : Set the WordPress user, this will be the administrator for the site and super admin for the network.
+	 * : Set the WordPress user, this will be the administrator for the site and administrator for the network if network_admin is not provided.
 	 *
-	 * [--super_user=<id|login|email>]
-	 * : This will be the super administrator for the network.
+	 * [--network_admin=<id|login|email>]
+	 * : This will be the administrator for the network.
 	 *
 	 * [--site_name=<site_name>]
 	 * : Name of the new network site
@@ -47,22 +47,22 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 		list( $domain, $path ) = $args;
 
 		$assoc_args = wp_parse_args( $assoc_args, array(
-			'super_user'    => false,
+			'network_admin'    => false,
 			'site_name'        => false,
 			'network_name'     => false,
 			'clone_network'    => false,
 			'options_to_clone' => false
 		) );
 
-		if ( $assoc_args['super_user'] ) {
+		if ( $assoc_args['network_admin'] ) {
 			$users = new \WP_CLI\Fetchers\User();
-			$user = $users->get( $assoc_args['super_user'] );
+			$user = $users->get( $assoc_args['network_admin'] );
 			if ( ! $user ) {
 				return new WP_Error( 'network_super_admin', __( 'Super user does not exist.', 'wp-multi-network' ) );
 			}
-			$super_user_id = $user->ID;
+			$network_admin_id = $user->ID;
 		} else {
-			$super_user_id = get_current_user_id();
+			$network_admin_id = get_current_user_id();
 		}
 
 		$clone_network    = $assoc_args['clone_network'];
@@ -83,7 +83,7 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 			'site_name'        => $assoc_args['site_name'],
 			'network_name'     => $assoc_args['network_name'],
 			'user_id'          => get_current_user_id(),
-			'super_user_id'    => $super_user_id,
+			'network_admin_id'    => $network_admin_id,
 			'clone_network'    => $clone_network,
 			'options_to_clone' => $options_to_clone
 		) );

--- a/includes/classes/class-wp-ms-networks-cli.php
+++ b/includes/classes/class-wp-ms-networks-cli.php
@@ -23,6 +23,12 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 	 * <path>
 	 * : Path for network
 	 *
+	 * --user=<id|login|email>
+	 * : Set the WordPress user, this will be the administrator for the site and super admin for the network.
+	 *
+	 * [--super_user=<id|login|email>]
+	 * : This will be the super administrator for the network.
+	 *
 	 * [--site_name=<site_name>]
 	 * : Name of new network
 	 *
@@ -38,10 +44,22 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 		list( $domain, $path ) = $args;
 
 		$assoc_args = wp_parse_args( $assoc_args, array(
+			'super_user'    => false,
 			'site_name'        => false,
 			'clone_network'    => false,
 			'options_to_clone' => false
 		) );
+
+		if ( $assoc_args['super_user'] ) {
+			$users = new \WP_CLI\Fetchers\User();
+			$user = $users->get( $assoc_args['super_user'] );
+			if ( ! $user ) {
+				return new WP_Error( 'network_super_admin', __( 'Super user does not exist.', 'wp-multi-network' ) );
+			}
+			$super_user_id = $user->ID;
+		} else {
+			$super_user_id = get_current_user_id();
+		}
 
 		$clone_network    = $assoc_args['clone_network'];
 		$options_to_clone = false;
@@ -60,6 +78,7 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 			'path'             => $path,
 			'site_name'        => $assoc_args['site_name'],
 			'user_id'          => get_current_user_id(),
+			'super_user_id'    => $super_user_id,
 			'clone_network'    => $clone_network,
 			'options_to_clone' => $options_to_clone
 		) );

--- a/includes/classes/class-wp-ms-networks-cli.php
+++ b/includes/classes/class-wp-ms-networks-cli.php
@@ -30,7 +30,10 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 	 * : This will be the super administrator for the network.
 	 *
 	 * [--site_name=<site_name>]
-	 * : Name of new network
+	 * : Name of the new network site
+	 *
+	 * [--network_name=<network_name>]
+	 * : Name of the new network
 	 *
 	 * [--clone_network=<clone_network>]
 	 * : ID of network to clone
@@ -46,6 +49,7 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 		$assoc_args = wp_parse_args( $assoc_args, array(
 			'super_user'    => false,
 			'site_name'        => false,
+			'network_name'     => false,
 			'clone_network'    => false,
 			'options_to_clone' => false
 		) );
@@ -77,6 +81,7 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 			'domain'           => $domain,
 			'path'             => $path,
 			'site_name'        => $assoc_args['site_name'],
+			'network_name'     => $assoc_args['network_name'],
 			'user_id'          => get_current_user_id(),
 			'super_user_id'    => $super_user_id,
 			'clone_network'    => $clone_network,

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -421,11 +421,6 @@ function add_network( $args = array() ) {
 
 		update_network_option( $new_network_id, 'site_name', $network_name );
 
-		switch_to_network( $new_network_id );
-		add_site_option( 'site_admins', array() );
-		grant_super_admin( $r['network_admin_id']);
-		restore_current_network();
-
 		/**
 		 * Fix upload_path for main sites on secondary networks
 		 * This applies only to new installs (WP 3.5+)
@@ -507,6 +502,14 @@ function add_network( $args = array() ) {
 
 		restore_current_network();
 	}
+
+	switch_to_network( $new_network_id );
+	// Grant super admin adds 'admin' as network admin if the 'site_admins' option does not exist.
+	if ( empty( $r['clone_network'] ) ) {
+		add_site_option( 'site_admins', array() );
+	}
+	grant_super_admin( $r['network_admin_id']);
+	restore_current_network();
 
 	// Clean network cache
 	clean_network_cache( array() );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -306,7 +306,7 @@ if ( ! function_exists( 'add_network' ) ) :
  *     @type integer $user_id          ID of the user to add as the site owner.
  *                                     Defaults to current user ID.
  *
- *     @type integer $super_user_id    ID of the user to add as the network administrator.
+ *     @type integer $network_admin_id    ID of the user to add as the network administrator.
  *                                     Defaults to current user ID.
  *
  *     @type array   $meta             Array of metadata to save to this network.
@@ -354,7 +354,7 @@ function add_network( $args = array() ) {
 		'site_name'        => __( 'New Network Site', 'wp-multi-network' ),
 		'network_name'     => __( 'New Network', 'wp-multi-network' ),
 		'user_id'          => get_current_user_id(),
-		'super_user_id'    => get_current_user_id(),
+		'network_admin_id'    => get_current_user_id(),
 		'meta'             => array( 'public' => get_option( 'blog_public', false ) ),
 		'clone_network'    => false,
 		'options_to_clone' => array_keys( network_options_to_copy() )
@@ -365,7 +365,7 @@ function add_network( $args = array() ) {
 		return new WP_Error( 'network_user', __( 'User does not exist.', 'wp-multi-network' ) );
 	}
 	// Bail if no super user with this ID
-	if ( empty( $r['super_user_id'] ) || ! get_userdata( $r['super_user_id'] ) ) {
+	if ( empty( $r['network_admin_id'] ) || ! get_userdata( $r['network_admin_id'] ) ) {
 		return new WP_Error( 'network_super_admin', __( 'Super user does not exist.', 'wp-multi-network' ) );
 	}
 	// Permissive sanitization for super admin usage
@@ -423,7 +423,7 @@ function add_network( $args = array() ) {
 
 		switch_to_network( $new_network_id );
 		add_site_option( 'site_admins', array() );
-		grant_super_admin( $r['super_user_id']);
+		grant_super_admin( $r['network_admin_id']);
 		restore_current_network();
 
 		/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -300,8 +300,15 @@ if ( ! function_exists( 'add_network' ) ) :
  *                                     product on a domain.
  *     @type string  $site_name        Name of the root blog to be created on
  *                                     the new network.
+ *
+ *     @type string  $network_name     Name of the new network.
+ *
  *     @type integer $user_id          ID of the user to add as the site owner.
  *                                     Defaults to current user ID.
+ *
+ *     @type integer $super_user_id    ID of the user to add as the network administrator.
+ *                                     Defaults to current user ID.
+ *
  *     @type array   $meta             Array of metadata to save to this network.
  *                                     Defaults to array( 'public' => false ).
  *     @type integer $clone_network    ID of network whose networkmeta values are
@@ -310,7 +317,7 @@ if ( ! function_exists( 'add_network' ) ) :
  *                                     when cloning - default NULL.
  * }
  *
- * @return integer ID of newly created network
+ * @return integer|WP_Error ID of newly created network
  */
 function add_network( $args = array() ) {
 	global $wpdb;
@@ -344,7 +351,8 @@ function add_network( $args = array() ) {
 	$r = wp_parse_args( $args, array(
 		'domain'           => '',
 		'path'             => '/',
-		'site_name'        => __( 'New Network', 'wp-multi-network' ),
+		'site_name'        => __( 'New Network Site', 'wp-multi-network' ),
+		'network_name'     => __( 'New Network', 'wp-multi-network' ),
 		'user_id'          => get_current_user_id(),
 		'super_user_id'    => get_current_user_id(),
 		'meta'             => array( 'public' => get_option( 'blog_public', false ) ),
@@ -404,6 +412,14 @@ function add_network( $args = array() ) {
 		if ( is_wp_error( $new_blog_id ) ) {
 			return $new_blog_id;
 		}
+		
+		if ( isset( $r['network_name'] ) && ! empty( $r['network_name'] ) ) {
+			$network_name = $r['network_name'];
+		} else {
+			$network_name = $r['site_name'];
+		}
+
+		update_network_option( $new_network_id, 'site_name', $network_name );
 
 		switch_to_network( $new_network_id );
 		add_site_option( 'site_admins', array() );
@@ -507,7 +523,7 @@ if ( ! function_exists( 'update_network' ) ) :
  *
  * @since 1.3
  *
- * @param integer id ID of network to modify
+ * @param integer $id ID of network to modify
  * @param string $domain New domain for network
  * @param string $path New path for network
  */


### PR DESCRIPTION
Added following arguments to the CLI. Changed site_name argument to refer to the new site. Now network name and site connected to the network can differ.
```
/*
 * --user=<id|login|email>
 * : Set the WordPress user, this will be the administrator for the site and administrator for the network if network_admin is not provided.
 *
 * [--network_admin=<id|login|email>]
 * : This will be the administrator for the network.
 *
 * [--site_name=<site_name>]
 * : Name of the new network site
 *
 * [--network_name=<network_name>]
 * : Name of the new network
*/
```

Only done manual testing.