### PR TITLE
When switching site, also switch network as well

### DIFF
--- a/tests/test-networkoperations.php
+++ b/tests/test-networkoperations.php
@@ -41,6 +41,37 @@ class WPMN_Tests_NetworkOperations extends WP_UnitTestCase {
 		$this->assertEquals( 1, $site->site_id, 'Site should be back in main network' );
 	}
 
+	public function test_switch_site() {
+		// Site first site and network
+		$network_id = $this->factory->network->create( array( 'domain' => 'wordpress.com', 'path' => '/', ) );
+		$site_id = $this->factory->blog->create( array( 'site_id' => $network_id ) );
+
+		// Site second site and network
+		$other_network_id = $this->factory->network->create( array( 'domain' => 'example.com', 'path' => '/', ) );
+		$site_id_diffent_network = $this->factory->blog->create( array( 'site_id' => $other_network_id ) );
+
+		// Assert default network is 1
+		$this->assertEquals( 1, get_current_network_id(), 'Network should start as 1' );
+
+		// Switch to first site
+		switch_to_blog( $site_id );
+		$this->assertEquals( $network_id, get_current_network_id(), 'Network should change to '. $network_id );
+		
+		// Switch to second site
+		switch_to_blog( $site_id_diffent_network );
+		$this->assertEquals( $other_network_id, get_current_network_id(), 'Network should change to '. $other_network_id );
+		// Switch to first site
+		restore_current_blog();
+
+		$this->assertEquals( $network_id, get_current_network_id(), 'Network should change to '. $network_id );
+
+		// Restore default site / network
+		restore_current_blog();
+
+		$this->assertEquals( 1, get_current_network_id(), 'Network should end as 1' );
+
+	}
+
 	public function test_switch_to_network() {
 		global $current_site;
 

--- a/wp-multi-network/includes/actions.php
+++ b/wp-multi-network/includes/actions.php
@@ -1,0 +1,12 @@
+<?php
+
+function switch_blog_and_network ( $new_blog, $prev_blog_id ){
+	$site_object = get_site( $new_blog );
+	if ( !($site_object instanceof WP_Site ) ){
+		return;
+	} 
+	if( get_current_network_id() != $site_object->site_id ) {
+	      switch_to_network( $site_object->site_id );
+	} 
+}
+add_action( 'switch_blog', 'switch_blog_and_network', 10, 2 ); 

--- a/wpmn-loader.php
+++ b/wpmn-loader.php
@@ -119,6 +119,7 @@ class WPMN_Loader {
 		// Functions & Core Compatibility
 		require $this->plugin_dir . 'includes/compat.php';
 		require $this->plugin_dir . 'includes/functions.php';
+		require $this->plugin_dir . 'includes/actions.php';
 
 		// WordPress Admin
 		if ( is_blog_admin() || is_network_admin() ) {


### PR DESCRIPTION
Currently when switching blog (site), the network is not changed. This can have issues when it comes to context aware function, that need the current network id to be correct. An example might be `wp_update_network_site_counts`. By switching network, it stops possible issues. 

Doing a get_site on switch_to_blog, will add some overhead. On sites with object caching, it may result in another query. However, most times using switch_to_blog the wp_site_query class is also used like in network admin. wp_site_query will prime the wp_site object in cache (in without object caching). But there will be places where this isn't the case. 

This PR includes tests, to prove it works. There maybe more tests that can be done. 

fixes: #118