### PR TITLE
Implement singleton pattern

### DIFF
--- a/wpmn-loader.php
+++ b/wpmn-loader.php
@@ -86,14 +86,40 @@ class WPMN_Loader {
 	private $admin_bar;
 
 	/**
+	 * Main WP Multi Network Loader instance.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @static object $instance
+	 * @see wpmn()
+	 *
+	 * @return WPMN_Loader|null The one true WP Multi Network Loader instance.
+	 */
+	public static function instance() {
+
+		// Store the instance locally to avoid private static replication.
+		static $instance = null;
+
+		// Only run these methods if they haven't been run previously.
+		if ( null === $instance ) {
+			$instance = new WPMN_Loader();
+			$instance->constants();
+			$instance->setup_globals();
+			$instance->includes();
+		}
+
+		// Always return the instance.
+		return $instance;
+
+	}
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.3.0
 	 */
 	public function __construct() {
-		$this->constants();
-		$this->setup_globals();
-		$this->includes();
+		// Do nothing here.
 	}
 
 	/**
@@ -178,14 +204,8 @@ add_action( 'muplugins_loaded', 'setup_multi_network' );
  *
  * @since 1.7.0
  *
- * @return WPMN_Loader WP Multi Network instance to use.
+ * @return WPMN_Loader|null The WP Multi Network instance.
  */
 function wpmn() {
-	static $wpmn = false;
-
-	if ( false === $wpmn ) {
-		$wpmn = new WPMN_Loader();
-	}
-
-	return $wpmn;
+	return WPMN_Loader::instance();
 }


### PR DESCRIPTION
At present, it's not possible to retrieve a reference to the WPMN plugin class. This PR ports the singleton pattern from BuddyPress so that one can write`$wpmn = wpmn();` when needed.

FWIW, my goal is to _unhook_ the WPMN menu (not my decision, I should add) but I can't retrieve a reference to `$this->admin_bar` since `$this` isn't exposed. I'll follow up with a PR that makes `admin_bar` a public property (I can't see any reason for it not to be) as that's outside the scope of this PR.