### PR TITLE
Make admin bar class instance a public property

### DIFF
--- a/wpmn-loader.php
+++ b/wpmn-loader.php
@@ -83,7 +83,7 @@ class WPMN_Loader {
 	 * @since 2.3.0
 	 * @var WP_MS_Networks_Admin_Bar
 	 */
-	private $admin_bar;
+	public $admin_bar;
 
 	/**
 	 * Constructor.


### PR DESCRIPTION
As mentioned in #140 it seems unnecessarily restrictive to make `$admin_bar` a private property and prevents other plugins from easily unhooking the WPMN admin menu bar. This PR merely changes the property to `public`.