### PR TITLE
Only check nonces on our forms

### DIFF
--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -294,6 +294,12 @@ class WP_MS_Networks_Admin {
 	 * @since 2.0.0
 	 */
 	public function route_save_handlers() {
+		// Bail -- our fields aren't being edited
+		// Otherwise we'll do an unnecessary nonce check
+		if ( ! $_POST['network_edit'] ) {
+			return;
+		}
+		
 		$action = filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING );
 		if ( empty( $action ) ) {
 			$alternative_actions = array( 'delete', 'delete_multiple', 'move' );

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -294,9 +294,10 @@ class WP_MS_Networks_Admin {
 	 * @since 2.0.0
 	 */
 	public function route_save_handlers() {
+
 		// Bail -- our fields aren't being edited
 		// Otherwise we'll do an unnecessary nonce check
-		if ( ! $_POST['network_edit'] ) {
+		if ( empty( $_POST['network_edit'] ) ) {
 			return;
 		}
 		


### PR DESCRIPTION
If our nonce field doesn't exist, bail. Otherwise we'll try to verify our nonce everywhere, which breaks all other forms.

Fixes #138