### PR TITLE
Issue/152 - Add Network: use correct $network_title variable.

### DIFF
--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -865,8 +865,8 @@ class WP_MS_Networks_Admin {
 		$success = '0';
 
 		if ( ! empty( $result ) && ! is_wp_error( $result ) ) {
-			if ( ! empty( $posted['title'] ) ) {
-				update_network_option( $result, 'site_name', $posted['title'] );
+			if ( ! empty( $network_title ) ) {
+				update_network_option( $result, 'site_name', $network_title );
 			}
 
 			update_network_option(


### PR DESCRIPTION
This commit fixes the saving of the New Network name/title.

Introduced in 3b732ac. Holy crap that was 3 years ago. 😢

Fixes #152.