### PR TITLE
Issue/159 - Admin/Create/Move: audit query and function arguments.

### DIFF
--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -880,7 +880,7 @@ class WP_MS_Networks_Admin {
 			: $network_title;
 
 		// Bail if missing fields.
-		if ( empty( $network_title ) || empty( $network_domain ) || empty( $network_path ) ) {
+		if ( empty( $network_domain ) || empty( $network_path ) ) {
 			$this->handle_redirect(
 				array(
 					'page'            => 'add-new-network',
@@ -889,22 +889,20 @@ class WP_MS_Networks_Admin {
 			);
 		}
 
-		// Add network.
-		$result = add_network(
-			array(
-				'domain'           => $network_domain,
-				'path'             => $network_path,
-				'site_name'        => $site_name,
-				'user_id'          => get_current_user_id(),
-				'clone_network'    => $clone,
-				'options_to_clone' => $options_to_clone,
-			)
+		// Arguments for add_network().
+		$args = array(
+			'domain'           => $network_domain,
+			'path'             => $network_path,
+			'site_name'        => $site_name,
+			'user_id'          => get_current_user_id(),
+			'clone_network'    => $clone,
+			'options_to_clone' => $options_to_clone,
 		);
 
-		// Default success value.
-		$success = '0';
+		// Add network.
+		$result = add_network( $args );
 
-		// No failure.
+		// Success!
 		if ( ! empty( $result ) && ! is_wp_error( $result ) ) {
 
 			// Update network name.
@@ -914,19 +912,26 @@ class WP_MS_Networks_Admin {
 
 			// Self-activate on new network.
 			update_network_option(
-				$result, 'active_sitewide_plugins', array(
+				$result,
+				'active_sitewide_plugins',
+				array(
 					'wp-multi-network/wpmn-loader.php' => time(),
 				)
 			);
 
-			// Success!
-			$success = '1';
+			// Redirect.
+			$this->handle_redirect(
+				array(
+					'network_created' => '1',
+				)
+			);
 		}
 
-		// Redirect.
+		// Failure.
 		$this->handle_redirect(
 			array(
-				'network_created' => $success,
+				'page'            => 'add-new-network',
+				'network_created' => '0',
 			)
 		);
 	}
@@ -1010,7 +1015,8 @@ class WP_MS_Networks_Admin {
 				add_query_arg(
 					array(
 						'site_moved' => 0,
-					), network_admin_url( 'sites.php' )
+					),
+					network_admin_url( 'sites.php' )
 				)
 			);
 			exit;
@@ -1020,12 +1026,13 @@ class WP_MS_Networks_Admin {
 		$site = get_site( $site_id );
 
 		// Bail if site cannot be found or new network is the same as existing.
-		if ( empty( $site ) || ( $site->network_id === $new_network ) ) {
+		if ( empty( $site ) || ( (int) $site->network_id === (int) $new_network ) ) {
 			wp_safe_redirect(
 				add_query_arg(
 					array(
 						'site_moved' => 0,
-					), network_admin_url( 'sites.php' )
+					),
+					network_admin_url( 'sites.php' )
 				)
 			);
 			exit;
@@ -1044,7 +1051,8 @@ class WP_MS_Networks_Admin {
 			add_query_arg(
 				array(
 					'site_moved' => $success,
-				), network_admin_url( 'sites.php' )
+				),
+				network_admin_url( 'sites.php' )
 			)
 		);
 		exit;
@@ -1198,7 +1206,8 @@ class WP_MS_Networks_Admin {
 
 		// Parse arguments.
 		$r = wp_parse_args(
-			$args, array(
+			$args,
+			array(
 				'page' => 'networks',
 			)
 		);

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
@@ -422,10 +422,20 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 		$network_home_url  = network_home_url();
 		restore_current_network();
 
+		// Setup the base URL.
 		$base_url = add_query_arg(
 			array(
 				'page' => 'networks',
 				'id'   => $network->id,
+			),
+			remove_query_arg(
+				array(
+					'action',
+					'network_created',
+					'page',
+					'site_moved',
+					'success',
+				)
 			)
 		);
 
@@ -436,7 +446,8 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 			$edit_network_url = add_query_arg(
 				array(
 					'action' => 'edit_network',
-				), $base_url
+				),
+				$base_url
 			);
 
 			$actions['edit'] = '<span class="edit"><a href="' . esc_url( $edit_network_url ) . '">' . esc_html__( 'Edit', 'wp-multi-network' ) . '</a></span>';
@@ -474,6 +485,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 		 */
 		$actions = apply_filters( 'manage_networks_action_links', array_filter( $actions ), $network->id, $network->sitename );
 
+		// Return all row actions.
 		return $this->row_actions( $actions );
 	}
 }

--- a/wp-multi-network/includes/metaboxes/edit-network.php
+++ b/wp-multi-network/includes/metaboxes/edit-network.php
@@ -168,8 +168,10 @@ function wpmn_edit_network_publish_metabox( $network = null ) {
 	$cancel_url = add_query_arg(
 		array(
 			'page' => 'networks',
-		), network_admin_url( 'admin.php' )
+		),
+		network_admin_url( 'admin.php' )
 	);
+
 	?>
 
 	<div class="submitbox">


### PR DESCRIPTION
This commit includes the following changes:

* Audit add_query_arg() usages and avoid collisions by removing known offenders
* Allow "empty" network name and site name in the UI; they will fallback to defaults in add_network()
* Add a bunch of inline docs
* Improve the readability by splitting parameters into separate lines
* When using func_get_args() in add_network(), count() the arguments before attempting to fallback

Fixes #159.