### PR TITLE
Issue/153 - Uploads/Clone: revert version_compare() flip. Split CLI logic.

### DIFF
--- a/wp-multi-network/includes/classes/class-wp-ms-network-command.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-network-command.php
@@ -81,14 +81,22 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 			$network_admin_id = get_current_user_id();
 		}
 
-		$clone_network    = $assoc_args['clone_network'];
-		$options_to_clone = false;
+		$clone_network = $assoc_args['clone_network'];
+		if ( empty( $clone_network ) ) {
+			$clone_network = get_current_site()->id;
+		}
 
-		if ( ! empty( $clone_network ) && ! get_network( $clone_network ) ) {
+		$network_exists = get_network( $clone_network );
+		if ( empty( $network_exists ) ) {
 			WP_CLI::error( sprintf( "Clone network %s doesn't exist.", $clone_network ) );
+		}
 
+		$options_to_clone = false;
+		if ( ! empty( $clone_network ) && ! empty( $network_exists ) ) {
 			if ( ! empty( $assoc_args['options_to_clone'] ) ) {
 				$options_to_clone = explode( ',', $assoc_args['options_to_clone'] );
+			} else {
+				$options_to_clone = array_keys( network_options_to_copy() );
 			}
 		}
 

--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -592,7 +592,7 @@ if ( ! function_exists( 'add_network' ) ) :
 			: get_site_option( 'ms_files_rewriting' );
 
 		// Not using rewriting, and using a newer version of WordPress than 3.7.
-		if ( empty( $use_files_rewriting ) && version_compare( $wp_version, '3.7', '>' ) ) {
+		if ( empty( $use_files_rewriting ) && version_compare( $wp_version, '3.7', '<' ) ) {
 
 			// WP_CONTENT_URL is locked to the current site and can't be overridden,
 			// so we have to replace the hostname the hard way.


### PR DESCRIPTION
This change reverts part of 60dd9c8 causing issues with upload paths, and ensures that the 'options_to_clone' argument is correctly used.

Fixes #153 