### PR TITLE
Save main site on network as network option.

### DIFF
--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -576,6 +576,8 @@ if ( ! function_exists( 'add_network' ) ) :
 			return $new_blog_id;
 		}
 
+		$r['network_meta']['main_site'] = $new_blog_id;
+
 		if ( empty( $r['network_meta']['site_name'] ) ) {
 			$r['network_meta']['site_name'] = ! empty( $r['network_name'] )
 				? $r['network_name']


### PR DESCRIPTION
A head of [#55802](https://core.trac.wordpress.org/ticket/55802) landing in core. Store main site on network as network option, to make easier to lookup and save lookup to blogs table.