### PR TITLE
Upgrade dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     "composer/installers": "^1.0 || ^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": ">4.8.20 <6.0",
-    "squizlabs/php_codesniffer": "3.*",
-    "wp-coding-standards/wpcs": "^2.2",
-    "phpcompatibility/phpcompatibility-wp": "^2.1",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1"
+    "phpunit/phpunit": "^9.6.0",
+    "squizlabs/php_codesniffer": "^3.11.0",
+    "wp-coding-standards/wpcs": "^3.1.0",
+    "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0"
   },
   "config": {
     "allow-plugins": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,18 +18,28 @@
 			<property name="text_domain" type="array">
 				<element value="wp-multi-network" />
 			</property>
-			<property name="check_translator_comments" value="true" />
 		</properties>
 	</rule>
 	<rule ref="PHPCompatibilityWP" />
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="create_networks" />
+				<element value="manage_networks" />
+				<element value="list_networks" />
+				<element value="delete_network" />
+				<element value="delete_networks" />
+				<element value="edit_network" />
+			</property>
+		</properties>
+	</rule>
 
 	<config name="testVersion" value="5.6-" />
 
 	<file>.</file>
 
 	<!-- Exclude directories we don't need to check. -->
-  <exclude-pattern>*/node_modules/*</exclude-pattern>
-  <exclude-pattern>*/tests/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
-
 </ruleset>

--- a/wp-multi-network/includes/classes/class-wp-ms-network-command.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-network-command.php
@@ -287,7 +287,7 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 			foreach ( $this->fetcher->get_many( $args ) as $plugin ) {
 				$status = $this->get_status( $plugin->file );
 				if ( $all && in_array( $status, array( 'active', 'active-network' ), true ) ) {
-					$needing_activation --;
+					--$needing_activation;
 					continue;
 				}
 

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -826,14 +826,14 @@ class WP_MS_Networks_Admin {
 								 * @param string     $network_actions Network action links, separated by pipe ( | ) characters.
 								 * @param WP_Network $network         Current network object.
 								 */
-								echo apply_filters( 'mynetworks_network_actions', $network_actions, $network ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+								echo apply_filters( 'mynetworks_network_actions', $network_actions, $network ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 								?>
 							</p>
 						</td>
 
 						<?php
 						restore_current_network();
-						$i++;
+						++$i;
 					}
 					echo '</tr>';
 				}

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-capabilities.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-capabilities.php
@@ -36,7 +36,7 @@ class WP_MS_Networks_Capabilities {
 	 * @param array  $args    Additional context for the capability check.
 	 * @return array Filtered required capabilities.
 	 */
-	public function map_meta_cap( $caps, $cap, $user_id, $args ) {
+	public function map_meta_cap( $caps, $cap, $user_id, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
 		// Map our meta capabilities to primitive capabilities first.
 		switch ( $cap ) {

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
@@ -326,8 +326,8 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 
 		<strong>
 			<?php
-			echo $link; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-			echo $network_states; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+			echo $link; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo $network_states; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			?>
 		</strong>
 

--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -586,8 +586,8 @@ if ( ! function_exists( 'add_network' ) ) :
 		 * @since 2.5.3
 		 */
 		do_action( 'added_network_blog', $new_blog_id, $new_network_id, $r );
-    
-    // add new blog id as network meta data against the new network
+
+		// add new blog id as network meta data against the new network.
 		$r['network_meta']['main_site'] = $new_blog_id;
 
 		if ( empty( $r['network_meta']['site_name'] ) ) {

--- a/wp-multi-network/includes/metaboxes/edit-network.php
+++ b/wp-multi-network/includes/metaboxes/edit-network.php
@@ -23,7 +23,7 @@ function wpmn_edit_network_details_metabox( $network = null ) {
 	?>
 
 	<table class="edit-network form-table">
-		<?php do_action('wpmn_edit_network_details_metabox_before_group', $network); ?>
+		<?php do_action( 'wpmn_edit_network_details_metabox_before_group', $network ); ?>
 
 		<tr class="form-field form-required">
 			<th scope="row">
@@ -46,7 +46,7 @@ function wpmn_edit_network_details_metabox( $network = null ) {
 			</td>
 		</tr>
 
-		<?php do_action('wpmn_edit_network_details_metabox_after_group', $network); ?>
+		<?php do_action( 'wpmn_edit_network_details_metabox_after_group', $network ); ?>
 	</table>
 
 	<?php
@@ -61,7 +61,7 @@ function wpmn_edit_network_new_site_metabox() {
 	?>
 
 	<table class="edit-network form-table">
-		<?php do_action('wpmn_edit_network_new_site_metabox_before_group'); ?>
+		<?php do_action( 'wpmn_edit_network_new_site_metabox_before_group' ); ?>
 
 		<tr class="form-field form-required">
 			<th scope="row">
@@ -73,7 +73,7 @@ function wpmn_edit_network_new_site_metabox() {
 			</td>
 		</tr>
 
-		<?php do_action('wpmn_edit_network_new_site_metabox_after_group'); ?>
+		<?php do_action( 'wpmn_edit_network_new_site_metabox_after_group' ); ?>
 	</table>
 
 	<?php


### PR DESCRIPTION
This PR updates all development dependencies to their latest versions. Additionally:

- PHPCS rules have been upgraded to align with the latest standards.
- PHPCBF has been run to fix automatically resolvable coding standard issues.

@spacedmonkey this includes wpcs too.
