### PR TITLE
Introduce PHPStan for Static Analysis

### DIFF
--- a/.github/workflows/phpstan-ci.yml
+++ b/.github/workflows/phpstan-ci.yml
@@ -9,13 +9,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: Install dependencies
         uses: php-actions/composer@v6
         with:
           php_version: '7.2'
-
-      - uses: php-actions/phpstan@v3
+      - name: Run PHPStan
+        uses: php-actions/phpstan@v3
         with:
           version: 'composer'
           php_version: '7.2'

--- a/.github/workflows/phpstan-ci.yml
+++ b/.github/workflows/phpstan-ci.yml
@@ -1,0 +1,22 @@
+name: PHPStan CI
+
+on: [push]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        uses: php-actions/composer@v6
+        with:
+          php_version: '7.2'
+
+      - uses: php-actions/phpstan@v3
+        with:
+          version: 'composer'
+          php_version: '7.2'
+          memory_limit: 1G

--- a/.github/workflows/phpstan-ci.yml
+++ b/.github/workflows/phpstan-ci.yml
@@ -1,21 +1,23 @@
-name: PHPStan CI
+name: Run PHPStan
 
 on: [push]
 
 jobs:
-  build-test:
+  run-phpstan:
+    name: Static Analysis
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Install dependencies
-        uses: php-actions/composer@v6
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
         with:
-          php_version: '7.2'
-      - name: Run PHPStan
-        uses: php-actions/phpstan@v3
+          php-version: 'latest'
+          coverage: none
+          tools: composer, cs2pr
+      - name: Install PHP dependencies
+        uses: ramsey/composer-install@v2
         with:
-          version: 'composer'
-          php_version: '7.2'
-          memory_limit: 1G
+          composer-options: '--prefer-dist --no-scripts'
+      - name: PHPStan
+        run: composer phpstan

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require-dev": {
     "phpcompatibility/phpcompatibility-wp": "^2.1.0",
-    "szepeviktor/phpstan-wordpress": "^2.0",
+    "szepeviktor/phpstan-wordpress": "^1.0",
     "wp-coding-standards/wpcs": "^3.1.0",
     "yoast/wp-test-utils": "^1.2"
   },

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,12 @@
   },
   "require-dev": {
     "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+    "szepeviktor/phpstan-wordpress": "^2.0",
     "wp-coding-standards/wpcs": "^3.1.0",
     "yoast/wp-test-utils": "^1.2"
+  },
+  "scripts": {
+    "phpstan": "phpstan analyse --memory-limit=1G"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,21 @@
     "composer/installers": "^1.0 || ^2.0"
   },
   "require-dev": {
+    "php-stubs/wp-cli-stubs": "^2.11",
     "phpcompatibility/phpcompatibility-wp": "^2.1.0",
+    "phpstan/extension-installer": "^1.4",
     "szepeviktor/phpstan-wordpress": "^1.0",
     "wp-coding-standards/wpcs": "^3.1.0",
     "yoast/wp-test-utils": "^1.2"
   },
   "scripts": {
-    "phpstan": "phpstan analyse --memory-limit=1G"
+    "phpstan": "vendor/bin/phpstan analyse --memory-limit=1G"
   },
   "config": {
     "allow-plugins": {
       "composer/installers": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true
     },
     "sort-packages": true
   }

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
     "php-stubs/wp-cli-stubs": "^2.11",
     "phpcompatibility/phpcompatibility-wp": "^2.1.0",
     "phpstan/extension-installer": "^1.4",
+    "phpstan/phpstan": "^1.12",
     "szepeviktor/phpstan-wordpress": "^1.0",
     "wp-coding-standards/wpcs": "^3.1.0",
     "yoast/wp-test-utils": "^1.2"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,7 @@
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+parameters:
+    level: 5
+    paths:
+        - wp-multi-network/includes
+        - wpmn-loader.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,18 @@
 includes:
     - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
-    level: 5
+    level: 0
     paths:
         - wp-multi-network/includes
         - wpmn-loader.php
+    ignoreErrors:
+        - '/^Call to static method add_command\(\) on an unknown class WP_CLI.$/'
+        - '/^Call to static method encode\(\) on an unknown class Requests_IDNAEncoder.$/'
+        - '/^Call to static method error\(\) on an unknown class WP_CLI.$/'
+        - '/^Call to static method success\(\) on an unknown class WP_CLI.$/'
+        - '/^Call to static method warning\(\) on an unknown class WP_CLI.$/'
+        - '/^Function WP_CLI\\Utils\\get_flag_value not found.$/'
+        - '/^Function WP_CLI\\Utils\\get_plugin_name not found.$/'
+        - '/^Instantiated class WP_CLI\\Fetchers\\Plugin not found.$/'
+        - '/^Instantiated class WP_CLI\\Fetchers\\User not found.$/'
+        - '/^Instantiated class WP_CLI\\Formatter not found.$/'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,18 +1,13 @@
-includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
     level: 0
     paths:
         - wp-multi-network/includes
         - wpmn-loader.php
+    scanFiles:
+        - %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-stubs.php
+        - %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php
+        #- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php
+        #- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-tools-stubs.php
     ignoreErrors:
-        - '/^Call to static method add_command\(\) on an unknown class WP_CLI.$/'
         - '/^Call to static method encode\(\) on an unknown class Requests_IDNAEncoder.$/'
-        - '/^Call to static method error\(\) on an unknown class WP_CLI.$/'
-        - '/^Call to static method success\(\) on an unknown class WP_CLI.$/'
-        - '/^Call to static method warning\(\) on an unknown class WP_CLI.$/'
-        - '/^Function WP_CLI\\Utils\\get_flag_value not found.$/'
-        - '/^Function WP_CLI\\Utils\\get_plugin_name not found.$/'
-        - '/^Instantiated class WP_CLI\\Fetchers\\Plugin not found.$/'
-        - '/^Instantiated class WP_CLI\\Fetchers\\User not found.$/'
-        - '/^Instantiated class WP_CLI\\Formatter not found.$/'
+

--- a/wp-multi-network/includes/classes/class-wp-ms-network-command.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-network-command.php
@@ -11,7 +11,7 @@
  *
  * @since 1.3.0
  */
-class WP_MS_Network_Command extends WP_CLI_Command {
+class WP_MS_Network_Command {
 
 	/**
 	 * Default fields to display for each object.
@@ -260,7 +260,7 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 	 * @param array $assoc_args Associative CLI arguments.
 	 */
 	public function plugin( $args, $assoc_args ) {
-		$this->fetcher = new \WP_CLI\Fetchers\Plugin();
+		$fetchers_plugin = new \WP_CLI\Fetchers\Plugin();
 		$action        = array_shift( $args );
 		if ( ! in_array( $action, array( 'activate', 'deactivate' ), true ) ) {
 			WP_CLI::error( sprintf( '%s is not a supported action.', $action ) );
@@ -284,7 +284,7 @@ class WP_MS_Network_Command extends WP_CLI_Command {
 					}, array_keys( get_plugins() )
 				);
 			}
-			foreach ( $this->fetcher->get_many( $args ) as $plugin ) {
+			foreach ( $fetchers_plugin->get_many( $args ) as $plugin ) {
 				$status = $this->get_status( $plugin->file );
 				if ( $all && in_array( $status, array( 'active', 'active-network' ), true ) ) {
 					--$needing_activation;

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
@@ -479,9 +479,9 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array  Action links as $slug => $link_markup pairs.
-		 * @param int    The current network ID.
-		 * @param string The current network name.
+		 * @param array  $filtered_acions Action links as $slug => $link_markup pairs.
+		 * @param int    $network_id The current network ID.
+		 * @param string $network_sitename The current network name.
 		 */
 		$actions = apply_filters( 'manage_networks_action_links', array_filter( $actions ), $network->id, $network->sitename );
 

--- a/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
@@ -449,10 +449,6 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 		}
 
 		if ( ! empty( $prepared_args ) ) {
-			if ( is_wp_error( $prepared_args ) ) {
-				return $prepared_args;
-			}
-
 			$domain = $prepared_args['domain'];
 			$path   = $prepared_args['path'];
 

--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -74,9 +74,9 @@ if ( ! function_exists( 'user_has_networks' ) ) :
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param array|bool|null List of network IDs or false. Anything but null will short-circuit
-		 *                        the process.
-		 * @param int             User ID for which the networks should be returned.
+		 * @param array|bool|null $my_networks List of network IDs or false. Anything but null will short-circuit
+		 *                                     the process.
+		 * @param int             $user_id User ID for which the networks should be returned.
 		 */
 		$my_networks = apply_filters( 'networks_pre_user_is_network_admin', null, $user_id );
 		if ( null !== $my_networks ) {
@@ -89,8 +89,8 @@ if ( ! function_exists( 'user_has_networks' ) ) :
 			 *
 			 * @since 2.0.0
 			 *
-			 * @param array|bool List of network IDs or false if no networks for the user.
-			 * @param int        User ID for which the networks should be returned.
+			 * @param array|bool $my_networks List of network IDs or false if no networks for the user.
+			 * @param int        $user_id User ID for which the networks should be returned.
 			 */
 			return apply_filters( 'networks_user_is_network_admin', $my_networks, $user_id );
 		}


### PR DESCRIPTION
This PR introduces [PHPStan](https://phpstan.org/) to improve static analysis for our codebase.

## Changes in this PR
- Added `szepeviktor/phpstan-wordpress` as a dev dependency.
- Created `phpstan.neon.dist` with an initial configuration.
- Added a Composer script (`composer phpstan`) for easy execution.
- Changes in the code to address the issues reported by PHPStan.

## Next Iterations
- Raise [rule levels](https://phpstan.org/user-guide/rule-levels) ++ until target level.
- Fix the reported errors.

Let me know your thoughts!
