### PR TITLE
Upgrade minimum PHP version to 7.2 across the project.

### DIFF
--- a/.github/workflows/php-sniffer-ci.yml
+++ b/.github/workflows/php-sniffer-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '5.6'
+          php-version: '7.2'
           coverage: none
           tools: composer, cs2pr
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,12 +20,12 @@ matrix:
       env: WP_VERSION=latest WP_MULTISITE=1
     - php: 7.2
       env: WP_VERSION=latest WP_MULTISITE=1
-    - php: 5.6
+    - php: 8.0
       env: WP_VERSION=latest WP_MULTISITE=1 PHPLINT=1
       dist: precise
     - php: 7.2
       env: WP_VERSION=4.9 WP_MULTISITE=1
-    - php: 5.6
+    - php: 8.0
       env: WP_VERSION=4.9 WP_MULTISITE=1
       dist: precise
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "source": "https://github.com/stuttter/wp-multi-network"
   },
   "require": {
-    "php": ">=5.2",
+    "php": ">=7.2",
     "composer/installers": "^1.0 || ^2.0"
   },
   "require-dev": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -34,7 +34,7 @@
 		</properties>
 	</rule>
 
-	<config name="testVersion" value="5.6-" />
+	<config name="testVersion" value="7.2-" />
 
 	<file>.</file>
 

--- a/wpmn-loader.php
+++ b/wpmn-loader.php
@@ -16,7 +16,7 @@
  * Text Domain:       wp-multi-network
  * Network:           true
  * Requires at least: 4.9
- * Requires PHP:      5.2
+ * Requires PHP:      7.2
  * Tested up to:      6.1
  * Version:           2.5.2
  */


### PR DESCRIPTION
Updated the PHPCS configuration, CI workflows, and composer requirements to reflect the new minimum PHP version of 7.2. Adjusted the supported PHP versions in `.travis.yml` and updated metadata in `wpmn-loader.php` accordingly. This ensures compatibility with a modern PHP environment.

Fixes #212