### PR TITLE
PHPStan Level 1

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,5 @@ parameters:
         #- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-i18n-stubs.php
         #- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-tools-stubs.php
     ignoreErrors:
-        - '/^Call to static method encode\(\) on an unknown class Requests_IDNAEncoder.$/'
-
+        - '/^Call to static method encode\(\) on an unknown class Requests_IDNAEncoder\.$/'
+        - '/^Constant WP_CONTENT_URL not found\.$/'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 0
+    level: 1
     paths:
         - wp-multi-network/includes
         - wpmn-loader.php

--- a/wp-multi-network/includes/classes/class-wp-ms-network-command.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-network-command.php
@@ -194,7 +194,7 @@ class WP_MS_Network_Command {
 	 * @param array $args       Positional CLI arguments.
 	 * @param array $assoc_args Associative CLI arguments.
 	 */
-	public function move_site( $args, $assoc_args ) {
+	public function move_site( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		list( $site_id, $new_network_id ) = $args;
 
 		$network_id = move_site( $site_id, $new_network_id );
@@ -261,7 +261,7 @@ class WP_MS_Network_Command {
 	 */
 	public function plugin( $args, $assoc_args ) {
 		$fetchers_plugin = new \WP_CLI\Fetchers\Plugin();
-		$action        = array_shift( $args );
+		$action          = array_shift( $args );
 		if ( ! in_array( $action, array( 'activate', 'deactivate' ), true ) ) {
 			WP_CLI::error( sprintf( '%s is not a supported action.', $action ) );
 		}

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -792,7 +792,7 @@ class WP_MS_Networks_Admin {
 				}
 				$num_rows = ceil( $num / $cols );
 				$split    = 0;
-				$rows     = [];
+				$rows     = array();
 				for ( $i = 1; $i <= $num_rows; $i++ ) {
 					$rows[] = array_slice( $my_networks, $split, $cols );
 					$split  = $split + $cols;

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -792,6 +792,7 @@ class WP_MS_Networks_Admin {
 				}
 				$num_rows = ceil( $num / $cols );
 				$split    = 0;
+				$rows     = [];
 				for ( $i = 1; $i <= $num_rows; $i++ ) {
 					$rows[] = array_slice( $my_networks, $split, $cols );
 					$split  = $split + $cols;

--- a/wp-multi-network/includes/compat.php
+++ b/wp-multi-network/includes/compat.php
@@ -86,12 +86,6 @@ if ( ! function_exists( 'wp_validate_site_url' ) ) :
 		$domains = substr_count( $domain, '.' ) > 1 ? (array) substr( $domain, 0, strpos( $domain, '.' ) ) : array();
 		$pieces  = array_filter( array_merge( $domains, $paths ) );
 		foreach ( $pieces as $slug ) {
-
-			// Bail if empty.
-			if ( empty( $slug ) ) {
-				return false;
-			}
-
 			// Bail if not lowercase or numbers.
 			if ( preg_match( '/[^a-z0-9]+/', $slug ) ) {
 				return false;


### PR DESCRIPTION
Setting PHPStan to level 1 revealed three minor issues, which have been addressed in this PR:

- Ignored the warning: *"Constant WP_CONTENT_URL not found."*
- Fixed: *"Variable $slug in empty() always exists and is not falsy."* ( `array_filter` has been applied  before.)
- Fixed: *"Variable $rows might not be defined."*