### PR TITLE
PHPStan Level 3

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 2
+    level: 3
     paths:
         - wp-multi-network/includes
         - wpmn-loader.php

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
@@ -414,7 +414,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 
 		// Bail if not primary column.
 		if ( $primary !== $column_name ) {
-			return;
+			return '';
 		}
 
 		switch_to_network( $network->id );

--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -120,7 +120,7 @@ if ( ! function_exists( 'get_main_site_for_network' ) ) :
 	 * @since 1.3.0
 	 *
 	 * @param int|WP_Network $network Optional. Network ID or object. Default is the current network.
-	 * @return int Main site ID for the network.
+	 * @return int|bool Main site ID for the network or false if network not found.
 	 */
 	function get_main_site_for_network( $network = null ) {
 		$network = get_network( $network );

--- a/wpmn-loader.php
+++ b/wpmn-loader.php
@@ -69,7 +69,7 @@ class WPMN_Loader {
 	 * @since 1.3.0
 	 * @var string
 	 */
-	public $asset_version = 202108250001;
+	public $asset_version = '202108250001';
 
 	/**
 	 * Network admin class instance.


### PR DESCRIPTION
This PR fixes 3 issues that came up with PHPStan at level 3:

- Function get_main_site_for_network() should return int but returns false.
- handle_row_actions should return the row actions HTML, or an empty string if the current column is not the primary column.
- Property WPMN_Loader\:\:$asset_version (string) does not accept default value of type int.
