### PR TITLE
PHPStan Level 5

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 4
+    level: 5
     paths:
         - wp-multi-network/includes
         - wpmn-loader.php

--- a/wp-multi-network/includes/classes/class-wp-ms-network-command.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-network-command.php
@@ -306,7 +306,7 @@ class WP_MS_Network_Command {
 				if ( 'activate' === $action ) {
 					activate_plugins( $plugin->file, '', $network_wide );
 				} else {
-					deactivate_plugins( $plugin->file, '', $network_wide );
+					deactivate_plugins( $plugin->file, false, $network_wide );
 				}
 
 				$this->active_output( $plugin->name, $plugin->file, $network_wide, 'activate' );

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -351,7 +351,7 @@ class WP_MS_Networks_Admin {
 	 * @since 2.0.0
 	 */
 	public function page_edit_network() {
-		$network_id = filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
+		$network_id = (int) filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
 		$network    = $network_id ? get_network( $network_id ) : null;
 
 		add_meta_box( 'wpmn-edit-network-details', esc_html__( 'Details', 'wp-multi-network' ), 'wpmn_edit_network_details_metabox', get_current_screen()->id, 'normal', 'high', array( $network ) );
@@ -475,7 +475,7 @@ class WP_MS_Networks_Admin {
 	 * @since 2.0.0
 	 */
 	private function page_move_site() {
-		$site_id = filter_input( INPUT_GET, 'blog_id', FILTER_SANITIZE_NUMBER_INT );
+		$site_id = (int) filter_input( INPUT_GET, 'blog_id', FILTER_SANITIZE_NUMBER_INT );
 		$site    = $site_id ? get_site( $site_id ) : null;
 
 		// Bail if invalid site ID.
@@ -548,7 +548,7 @@ class WP_MS_Networks_Admin {
 	 * @since 2.0.0
 	 */
 	private function page_delete_network() {
-		$network_id = filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
+		$network_id = (int) filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
 		$network    = $network_id ? get_network( $network_id ) : null;
 
 		// Bail if invalid network ID.
@@ -944,7 +944,7 @@ class WP_MS_Networks_Admin {
 	private function handle_update_network() {
 
 		// Sanitize network ID.
-		$network_id = filter_input( INPUT_POST, 'network_id', FILTER_SANITIZE_NUMBER_INT );
+		$network_id = (int) filter_input( INPUT_POST, 'network_id', FILTER_SANITIZE_NUMBER_INT );
 
 		// Bail if invalid network.
 		if ( ! get_network( $network_id ) ) {
@@ -1006,8 +1006,8 @@ class WP_MS_Networks_Admin {
 	private function handle_move_site() {
 
 		// Sanitize values.
-		$site_id     = filter_input( INPUT_GET, 'blog_id', FILTER_SANITIZE_NUMBER_INT );
-		$new_network = filter_input( INPUT_POST, 'to', FILTER_SANITIZE_NUMBER_INT );
+		$site_id     = (int) filter_input( INPUT_GET, 'blog_id', FILTER_SANITIZE_NUMBER_INT );
+		$new_network = (int) filter_input( INPUT_POST, 'to', FILTER_SANITIZE_NUMBER_INT );
 
 		// Bail if no site ID.
 		if ( empty( $site_id ) ) {
@@ -1075,7 +1075,7 @@ class WP_MS_Networks_Admin {
 		}
 
 		// Sanitize network ID.
-		$network_id = filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
+		$network_id = (int) filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
 
 		// Default to/from arrays.
 		$moving_to   = array();
@@ -1130,7 +1130,7 @@ class WP_MS_Networks_Admin {
 	private function handle_delete_network() {
 
 		// Sanitize values.
-		$network_id = filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
+		$network_id = (int) filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
 		$override   = (bool) filter_input( INPUT_POST, 'override' );
 
 		// Attempt to delete network.

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -157,7 +157,7 @@ class WP_MS_Networks_Admin {
 			return;
 		}
 
-		wp_register_style( 'wp-multi-network', wpmn()->plugin_url . 'assets/css/wp-multi-network.css', array(), wpmn()->asset_version, false );
+		wp_register_style( 'wp-multi-network', wpmn()->plugin_url . 'assets/css/wp-multi-network.css', array(), wpmn()->asset_version );
 		wp_register_script( 'wp-multi-network', wpmn()->plugin_url . 'assets/js/wp-multi-network.js', array( 'jquery', 'post' ), wpmn()->asset_version, true );
 
 		wp_enqueue_style( 'wp-multi-network' );

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
@@ -279,7 +279,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 		}
 
 		?>
-		<label class="screen-reader-text" for="network_<?php echo esc_attr( $network->id ); ?>">
+		<label class="screen-reader-text" for="network_<?php echo esc_attr( strval( $network->id ) ); ?>">
 			<?php
 			printf(
 				/* translators: %s: network name */
@@ -288,7 +288,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 			);
 			?>
 		</label>
-		<input type="checkbox" id="network_<?php echo esc_attr( $network->id ); ?>" name="all_networks[]" value="<?php echo esc_attr( $network->id ); ?>">
+		<input type="checkbox" id="network_<?php echo esc_attr( strval( $network->id ) ); ?>" name="all_networks[]" value="<?php echo esc_attr( strval( $network->id ) ); ?>">
 		<?php
 	}
 
@@ -396,7 +396,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * @param WP_Network $network The current network object.
 	 */
 	public function column_id( $network ) {
-		echo esc_html( $network->id );
+		echo esc_html( strval( $network->id ) );
 	}
 
 	/**

--- a/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
@@ -193,8 +193,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 			$networks[] = $this->prepare_response_for_collection( $data );
 		}
 
-		$total_networks = (int) $query->found_networks;
-		$max_pages      = (int) $query->max_num_pages;
+		$total_networks = $query->found_networks;
+		$max_pages      = $query->max_num_pages;
 
 		if ( $total_networks < 1 ) {
 			// Out-of-bounds, run the query again without LIMIT for total count.
@@ -203,13 +203,13 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 			$query                  = new WP_Network_Query();
 			$prepared_args['count'] = true;
 
-			$total_networks = $query->query( $prepared_args );
-			$max_pages      = ceil( $total_networks / $request['per_page'] );
+			$total_networks = (int) $query->query( $prepared_args );
+			$max_pages      = (int) ceil( $total_networks / $request['per_page'] );
 		}
 
 		$response = rest_ensure_response( $networks );
-		$response->header( 'X-WP-Total', $total_networks );
-		$response->header( 'X-WP-TotalPages', $max_pages );
+		$response->header( 'X-WP-Total', strval( $total_networks ) );
+		$response->header( 'X-WP-TotalPages', strval( $max_pages ) );
 
 		$base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ) );
 

--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -616,8 +616,9 @@ if ( ! function_exists( 'add_network' ) ) :
 			$upload_url      = $upload_url . '/uploads';
 
 			$upload_dir = WP_CONTENT_DIR;
-			if ( 0 === strpos( $upload_dir, ABSPATH ) ) {
-				$upload_dir = substr( $upload_dir, strlen( ABSPATH ) );
+			$needle     = strval( ABSPATH );
+			if ( 0 === strpos( $upload_dir, $needle ) ) {
+				$upload_dir = substr( $upload_dir, strlen( $needle ) );
 			}
 			$upload_dir .= '/uploads';
 

--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -717,7 +717,7 @@ if ( ! function_exists( 'update_network' ) ) :
 		$path    = wp_sanitize_site_path( $path );
 
 		// Bail if site URL is invalid.
-		if ( ! wp_validate_site_url( $domain, $path, $site_id ) ) {
+		if ( ! wp_validate_site_url( $domain, $path, strval( $site_id ) ) ) {
 			/* translators: %s: site domain and path */
 			return new WP_Error( 'blog_bad', sprintf( __( 'The site "%s" is invalid, not available, or already exists.', 'wp-multi-network' ), $domain . $path ) );
 		}

--- a/wp-multi-network/includes/metaboxes/edit-network.php
+++ b/wp-multi-network/includes/metaboxes/edit-network.php
@@ -118,7 +118,7 @@ function wpmn_edit_network_assign_sites_metabox( $network = null ) {
 
 						<?php if ( ( (int) $site->network_id !== (int) $network->id ) && ! is_main_site_for_network( $site->id ) ) : ?>
 
-							<option value="<?php echo esc_attr( $site->id ); ?>">
+							<option value="<?php echo esc_attr( strval( $site->id ) ); ?>">
 								<?php echo esc_html( sprintf( '%1$s (%2$s%3$s)', $site->blogname, $site->domain, $site->path ) ); ?>
 							</option>
 
@@ -139,7 +139,7 @@ function wpmn_edit_network_assign_sites_metabox( $network = null ) {
 
 						<?php if ( (int) $site->network_id === (int) $network->id ) : ?>
 
-							<option value="<?php echo esc_attr( $site->id ); ?>" <?php disabled( is_main_site_for_network( $site->id ) ); ?>>
+							<option value="<?php echo esc_attr( strval( $site->id ) ); ?>" <?php disabled( is_main_site_for_network( $site->id ) ); ?>>
 								<?php echo esc_html( sprintf( '%1$s (%2$s%3$s)', $site->blogname, $site->domain, $site->path ) ); ?>
 							</option>
 
@@ -241,7 +241,7 @@ function wpmn_edit_network_publish_metabox( $network = null ) {
 
 				?>
 				<input type="hidden" name="action" value="<?php echo esc_attr( $action ); ?>">
-				<input type="hidden" name="network_id" value="<?php echo esc_attr( $network_id ); ?>">
+				<input type="hidden" name="network_id" value="<?php echo esc_attr( strval( $network_id ) ); ?>">
 			</div>
 			<div class="clear"></div>
 		</div>

--- a/wp-multi-network/includes/metaboxes/edit-network.php
+++ b/wp-multi-network/includes/metaboxes/edit-network.php
@@ -89,7 +89,7 @@ function wpmn_edit_network_new_site_metabox() {
 function wpmn_edit_network_assign_sites_metabox( $network = null ) {
 	$to = get_sites(
 		array(
-			'site__not_in' => get_main_site_id( $network->id ),
+			'site__not_in' => array( get_main_site_id( $network->id ) ),
 			'network_id'   => $network->id,
 		)
 	);

--- a/wp-multi-network/includes/metaboxes/move-site.php
+++ b/wp-multi-network/includes/metaboxes/move-site.php
@@ -138,7 +138,7 @@ function wpmn_move_site_assign_metabox( $site = null ) {
 
 				?>
 				<input type="hidden" name="action" value="move">
-				<input type="hidden" name="from" value="<?php echo esc_attr( $site->network_id ); ?>">
+				<input type="hidden" name="from" value="<?php echo esc_attr( strval( $site->network_id ) ); ?>">
 			</div>
 			<div class="clear"></div>
 		</div>


### PR DESCRIPTION
This PR raises the PHPStan static analysis level from Level 4 to Level 5 for the plugin. To comply with the stricter analysis, there are mainly modifications to improve the type safety.

These changes should not affect the runtime behaviour of the plugin but make the codebase stricter, safer, and better aligned with modern PHP and WordPress standards.