### PR TITLE
PHPStan Level 6

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     paths:
         - wp-multi-network/includes
         - wpmn-loader.php

--- a/wp-multi-network/includes/classes/class-wp-ms-network-command.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-network-command.php
@@ -17,7 +17,7 @@ class WP_MS_Network_Command {
 	 * Default fields to display for each object.
 	 *
 	 * @since 1.3.0
-	 * @var array
+	 * @var string[]
 	 */
 	protected $obj_fields = array(
 		'id',
@@ -54,12 +54,12 @@ class WP_MS_Network_Command {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array $args       Positional CLI arguments.
-	 * @param array $assoc_args Associative CLI arguments.
+	 * @param string[]             $args Positional CLI arguments.
+	 * @param array<string, mixed> $assoc_args Associative CLI arguments.
 	 * @return void
 	 */
 	public function create( $args, $assoc_args ) {
-		list( $domain, $path ) = $args;
+		[ $domain, $path ] = $args;
 
 		$assoc_args = wp_parse_args(
 			$assoc_args, array(
@@ -123,19 +123,19 @@ class WP_MS_Network_Command {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array $args       Positional CLI arguments.
-	 * @param array $assoc_args Associative CLI arguments.
+	 * @param string[]             $args Positional CLI arguments.
+	 * @param array<string, mixed> $assoc_args Associative CLI arguments.
 	 * @return void
 	 */
 	public function update( $args, $assoc_args ) {
-		list( $id, $domain ) = $args;
+		[ $id, $domain ] = $args;
 
 		$defaults   = array(
 			'path' => '',
 		);
 		$assoc_args = wp_parse_args( $assoc_args, $defaults );
 
-		$network_id = update_network( $id, $domain, $assoc_args['path'] );
+		$network_id = update_network( (int) $id, $domain, $assoc_args['path'] );
 
 		if ( is_wp_error( $network_id ) ) {
 			WP_CLI::error( $network_id );
@@ -155,12 +155,12 @@ class WP_MS_Network_Command {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array $args       Positional CLI arguments.
-	 * @param array $assoc_args Associative CLI arguments.
+	 * @param string[]             $args Positional CLI arguments.
+	 * @param array<string, mixed> $assoc_args Associative CLI arguments.
 	 * @return void
 	 */
 	public function delete( $args, $assoc_args ) {
-		list( $id ) = $args;
+		[ $id ] = $args;
 
 		$assoc_args = wp_parse_args(
 			$assoc_args, array(
@@ -168,7 +168,7 @@ class WP_MS_Network_Command {
 			)
 		);
 
-		$network_id = delete_network( $id, $assoc_args['delete_blogs'] );
+		$network_id = delete_network( (int) $id, $assoc_args['delete_blogs'] );
 
 		if ( is_wp_error( $network_id ) ) {
 			WP_CLI::error( $network_id );
@@ -190,14 +190,14 @@ class WP_MS_Network_Command {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array $args       Positional CLI arguments.
-	 * @param array $assoc_args Associative CLI arguments.
+	 * @param string[]             $args Positional CLI arguments.
+	 * @param array<string, mixed> $assoc_args Associative CLI arguments.
 	 * @return void
 	 */
 	public function move_site( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		list( $site_id, $new_network_id ) = $args;
+		[ $site_id, $new_network_id ] = $args;
 
-		$network_id = move_site( $site_id, $new_network_id );
+		$network_id = move_site( (int) $site_id, (int) $new_network_id );
 
 		if ( is_wp_error( $network_id ) ) {
 			WP_CLI::error( $network_id );
@@ -227,8 +227,8 @@ class WP_MS_Network_Command {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array $args       Positional CLI arguments.
-	 * @param array $assoc_args Associative CLI arguments.
+	 * @param string[]             $args Positional CLI arguments.
+	 * @param array<string, mixed> $assoc_args Associative CLI arguments.
 	 * @return void
 	 */
 	public function list_( $args, $assoc_args ) {
@@ -257,8 +257,8 @@ class WP_MS_Network_Command {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array $args       Positional CLI arguments.
-	 * @param array $assoc_args Associative CLI arguments.
+	 * @param string[]             $args Positional CLI arguments.
+	 * @param array<string, mixed> $assoc_args Associative CLI arguments.
 	 * @return void
 	 */
 	public function plugin( $args, $assoc_args ) {
@@ -328,7 +328,7 @@ class WP_MS_Network_Command {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array $assoc_args Associative CLI arguments. Passed by reference.
+	 * @param array<string, mixed> $assoc_args Associative CLI arguments. Passed by reference.
 	 * @return WP_CLI\Formatter WP-CLI formatter instance.
 	 */
 	protected function get_formatter( &$assoc_args ) {

--- a/wp-multi-network/includes/classes/class-wp-ms-network-command.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-network-command.php
@@ -56,6 +56,7 @@ class WP_MS_Network_Command {
 	 *
 	 * @param array $args       Positional CLI arguments.
 	 * @param array $assoc_args Associative CLI arguments.
+	 * @return void
 	 */
 	public function create( $args, $assoc_args ) {
 		list( $domain, $path ) = $args;
@@ -74,7 +75,7 @@ class WP_MS_Network_Command {
 			$users = new \WP_CLI\Fetchers\User();
 			$user  = $users->get( $assoc_args['network_admin'] );
 			if ( ! $user ) {
-				return new WP_Error( 'network_super_admin', 'Super user does not exist.' );
+				WP_CLI::error( 'Super user does not exist.' );
 			}
 			$network_admin_id = $user->ID;
 		} else {
@@ -124,6 +125,7 @@ class WP_MS_Network_Command {
 	 *
 	 * @param array $args       Positional CLI arguments.
 	 * @param array $assoc_args Associative CLI arguments.
+	 * @return void
 	 */
 	public function update( $args, $assoc_args ) {
 		list( $id, $domain ) = $args;
@@ -155,6 +157,7 @@ class WP_MS_Network_Command {
 	 *
 	 * @param array $args       Positional CLI arguments.
 	 * @param array $assoc_args Associative CLI arguments.
+	 * @return void
 	 */
 	public function delete( $args, $assoc_args ) {
 		list( $id ) = $args;
@@ -189,6 +192,7 @@ class WP_MS_Network_Command {
 	 *
 	 * @param array $args       Positional CLI arguments.
 	 * @param array $assoc_args Associative CLI arguments.
+	 * @return void
 	 */
 	public function move_site( $args, $assoc_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		list( $site_id, $new_network_id ) = $args;
@@ -225,6 +229,7 @@ class WP_MS_Network_Command {
 	 *
 	 * @param array $args       Positional CLI arguments.
 	 * @param array $assoc_args Associative CLI arguments.
+	 * @return void
 	 */
 	public function list_( $args, $assoc_args ) {
 		$items     = get_networks();
@@ -254,6 +259,7 @@ class WP_MS_Network_Command {
 	 *
 	 * @param array $args       Positional CLI arguments.
 	 * @param array $assoc_args Associative CLI arguments.
+	 * @return void
 	 */
 	public function plugin( $args, $assoc_args ) {
 		$fetchers_plugin = new \WP_CLI\Fetchers\Plugin();
@@ -276,7 +282,7 @@ class WP_MS_Network_Command {
 			if ( $all ) {
 				$args = array_map(
 					function ( $file ) {
-							return \WP_CLI\Utils\get_plugin_name( $file );
+						return \WP_CLI\Utils\get_plugin_name( $file );
 					}, array_keys( get_plugins() )
 				);
 			}
@@ -373,6 +379,7 @@ class WP_MS_Network_Command {
 	 * @param string $file         Plugin main file path relative to the plugins directory.
 	 * @param bool   $network_wide Whether to check network-wide or not.
 	 * @param string $action       Action performed.
+	 * @return void
 	 */
 	private function active_output( $name, $file, $network_wide, $action ) {
 		$network_wide = $network_wide || ( is_multisite() && is_network_only_plugin( $file ) );

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin-bar.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin-bar.php
@@ -40,6 +40,7 @@ class WP_MS_Networks_Admin_Bar {
 	 *
 	 * @since 2.2.0
 	 * @since 3.0.0 Prevent rendering of CSS if admin bar is not shown.
+	 * @return void
 	 */
 	public function admin_print_styles() {
 		if ( ! is_admin_bar_showing() ) {
@@ -61,6 +62,7 @@ class WP_MS_Networks_Admin_Bar {
 	 * @since 2.2.0
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin bar instance.
+	 * @return void
 	 */
 	public function admin_bar( $wp_admin_bar ) {
 

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -20,7 +20,7 @@ class WP_MS_Networks_Admin {
 	 * Internal storage for feedback strings to avoid generating them multiple times.
 	 *
 	 * @since 2.0.0
-	 * @var array
+	 * @var array<string, array<int, string>>
 	 */
 	private $feedback_strings = array();
 
@@ -51,9 +51,9 @@ class WP_MS_Networks_Admin {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array $actions Array of action links.
-	 * @param int   $blog_id Current site ID.
-	 * @return array Adjusted action links.
+	 * @param array<string, string> $actions Array of action links.
+	 * @param int                   $blog_id Current site ID.
+	 * @return array<string, string> Adjusted action links.
 	 */
 	public function add_move_blog_link( $actions = array(), $blog_id = 0 ) {
 
@@ -1208,7 +1208,7 @@ class WP_MS_Networks_Admin {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param array $args Optional. URL query arguments. Default empty array.
+	 * @param array<string, string> $args Optional. URL query arguments. Default empty array.
 	 * @return void
 	 */
 	private function handle_redirect( $args = array() ) {
@@ -1221,7 +1221,7 @@ class WP_MS_Networks_Admin {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array $args Optional. URL query arguments. Default empty array.
+	 * @param array<string, string> $args Optional. URL query arguments. Default empty array.
 	 * @return string Absolute URL to the networks page.
 	 */
 	private function admin_url( $args = array() ) {
@@ -1258,6 +1258,7 @@ class WP_MS_Networks_Admin {
 	 * Checks the nonce for a network management form submission.
 	 *
 	 * @since 2.1.0
+	 * @return void
 	 */
 	private function check_nonce() {
 		check_admin_referer( 'edit_network', 'network_edit' );

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -83,6 +83,7 @@ class WP_MS_Networks_Admin {
 	 * permissions on the current site.
 	 *
 	 * @since 1.3.0
+	 * @return void
 	 */
 	public function admin_menu() {
 
@@ -101,6 +102,7 @@ class WP_MS_Networks_Admin {
 	 * WP_MS_Networks_List_Table class also.
 	 *
 	 * @since 1.3.0
+	 * @return void
 	 */
 	public function network_admin_menu() {
 		$page = add_menu_page( esc_html__( 'Networks', 'wp-multi-network' ), esc_html__( 'Networks', 'wp-multi-network' ), 'manage_networks', 'networks', array( $this, 'route_pages' ), 'dashicons-networking', -1 );
@@ -118,6 +120,7 @@ class WP_MS_Networks_Admin {
 	 * network dashboard.
 	 *
 	 * @since 1.5.2
+	 * @return void
 	 */
 	public function network_admin_menu_separator() {
 		$GLOBALS['menu']['-2'] = array( '', 'read', 'separator', '', 'wp-menu-separator' ); // phpcs:ignore WordPress.Variables.GlobalVariables.OverrideProhibited
@@ -131,6 +134,7 @@ class WP_MS_Networks_Admin {
 	 *
 	 * @global string $plugin_page
 	 * @global string $submenu_file
+	 * @return void
 	 */
 	public function fix_menu_highlight_for_move_page() {
 		global $plugin_page, $submenu_file;
@@ -149,6 +153,7 @@ class WP_MS_Networks_Admin {
 	 * @since 2.0.0
 	 *
 	 * @param string $page Optional. Current page hook. Default empty string.
+	 * @return void
 	 */
 	public function enqueue_scripts( $page = '' ) {
 
@@ -168,6 +173,7 @@ class WP_MS_Networks_Admin {
 	 * Sets feedback strings for network admin actions.
 	 *
 	 * @since 2.1.0
+	 * @return void
 	 */
 	public function set_feedback_strings() {
 		$this->feedback_strings = array(
@@ -194,6 +200,7 @@ class WP_MS_Networks_Admin {
 	 * Prints feedback notices for network admin actions as necessary.
 	 *
 	 * @since 1.3.0
+	 * @return void
 	 */
 	public function network_admin_notices() {
 		$message = '';
@@ -233,6 +240,7 @@ class WP_MS_Networks_Admin {
 	 * Routes the current request to the correct page.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	public function route_pages() {
 
@@ -290,6 +298,7 @@ class WP_MS_Networks_Admin {
 	 * Handles network management form submissions.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	public function route_save_handlers() {
 
@@ -349,6 +358,7 @@ class WP_MS_Networks_Admin {
 	 * Renders the new network creation dashboard page.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	public function page_edit_network() {
 		$network_id = (int) filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
@@ -424,6 +434,7 @@ class WP_MS_Networks_Admin {
 	 * @since 2.0.0
 	 *
 	 * @uses WP_MS_Networks_List_Table List_Table iterator for networks
+	 * @return void
 	 */
 	private function page_all_networks() {
 		$wp_list_table = new WP_MS_Networks_List_Table();
@@ -473,6 +484,7 @@ class WP_MS_Networks_Admin {
 	 * Renders the dashboard screen for moving sites -- accessed from the "Sites" screen.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	private function page_move_site() {
 		$site_id = (int) filter_input( INPUT_GET, 'blog_id', FILTER_SANITIZE_NUMBER_INT );
@@ -546,6 +558,7 @@ class WP_MS_Networks_Admin {
 	 * Renders the delete network page.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	private function page_delete_network() {
 		$network_id = (int) filter_input( INPUT_GET, 'id', FILTER_SANITIZE_NUMBER_INT );
@@ -637,6 +650,7 @@ class WP_MS_Networks_Admin {
 	 * Renders the delete multiple networks page.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	private function page_delete_networks() {
 		$network_id   = get_main_network_id();
@@ -756,6 +770,7 @@ class WP_MS_Networks_Admin {
 	 * @since 2.0.0
 	 *
 	 * @global wpdb $wpdb WordPress database abstraction object.
+	 * @return void
 	 */
 	public function page_my_networks() {
 		global $wpdb;
@@ -848,6 +863,7 @@ class WP_MS_Networks_Admin {
 	 * Handles the request to add a new network.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	private function handle_add_network() {
 
@@ -940,6 +956,7 @@ class WP_MS_Networks_Admin {
 	 * Handles the request to update a network.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	private function handle_update_network() {
 
@@ -1002,6 +1019,7 @@ class WP_MS_Networks_Admin {
 	 * Handles the request to move a site to another network.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	private function handle_move_site() {
 
@@ -1062,6 +1080,7 @@ class WP_MS_Networks_Admin {
 	 * Handles the request to reassign sites to another network.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	private function handle_reassign_sites() {
 
@@ -1126,6 +1145,7 @@ class WP_MS_Networks_Admin {
 	 * Handles the request to delete a network.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	private function handle_delete_network() {
 
@@ -1153,6 +1173,7 @@ class WP_MS_Networks_Admin {
 	 * Handles the request to delete multiple networks.
 	 *
 	 * @since 2.0.0
+	 * @return void
 	 */
 	private function handle_delete_networks() {
 
@@ -1188,6 +1209,7 @@ class WP_MS_Networks_Admin {
 	 * @since 2.0.0
 	 *
 	 * @param array $args Optional. URL query arguments. Default empty array.
+	 * @return void
 	 */
 	private function handle_redirect( $args = array() ) {
 		wp_safe_redirect( $this->admin_url( $args ) );

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -396,7 +396,7 @@ class WP_MS_Networks_Admin {
 						<div id="post-body-content">
 							<div id="titlediv">
 								<div id="titlewrap">
-									<label class="screen-reader-text" id="title-prompt-text" for="title"><?php echo esc_html_e( 'Enter network title here', 'wp-multi-network' ); ?></label>
+									<label class="screen-reader-text" id="title-prompt-text" for="title"><?php esc_html_e( 'Enter network title here', 'wp-multi-network' ); ?></label>
 									<input type="text" name="title" size="30" id="title" spellcheck="true" autocomplete="off" value="<?php echo esc_attr( $network_title ); ?>">
 								</div>
 							</div>

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-capabilities.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-capabilities.php
@@ -31,11 +31,11 @@ class WP_MS_Networks_Capabilities {
 	 *
 	 * @since 2.3.0
 	 *
-	 * @param array  $caps    Array of required capabilities.
-	 * @param string $cap     Capability to map.
-	 * @param int    $user_id User ID.
-	 * @param array  $args    Additional context for the capability check.
-	 * @return array Filtered required capabilities.
+	 * @param string[] $caps Array of required capabilities.
+	 * @param string   $cap Capability to map.
+	 * @param int      $user_id User ID.
+	 * @param mixed[]  $args Additional context for the capability check.
+	 * @return string[] Filtered required capabilities.
 	 */
 	public function map_meta_cap( $caps, $cap, $user_id, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
@@ -68,7 +68,7 @@ class WP_MS_Networks_Capabilities {
 	 *
 	 * @since 2.3.0
 	 *
-	 * @return array List of primitive global capabilities.
+	 * @return string[] List of primitive global capabilities.
 	 */
 	private function get_global_capabilities() {
 		$global_capabilities = array(

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-capabilities.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-capabilities.php
@@ -20,6 +20,7 @@ class WP_MS_Networks_Capabilities {
 	 * Adds hooks for networks capabilities.
 	 *
 	 * @since 2.3.0
+	 * @return void
 	 */
 	public function add_hooks() {
 		add_filter( 'map_meta_cap', array( $this, 'map_meta_cap' ), 10, 4 );

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
@@ -108,7 +108,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @return array Bulk actions as $slug => $label pairs.
+	 * @return array<string, string> Bulk actions as $slug => $label pairs.
 	 */
 	public function get_bulk_actions() {
 		$actions = array();
@@ -147,7 +147,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @return array Columns as $slug => $label pairs.
+	 * @return array<string, string> Columns as $slug => $label pairs.
 	 */
 	public function get_columns() {
 		$columns = array(
@@ -174,7 +174,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @return array Columns as $slug => $orderby_field pairs.
+	 * @return array<string, string> Columns as $slug => $orderby_field pairs.
 	 */
 	public function get_sortable_columns() {
 		return array(

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
@@ -47,6 +47,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * Prepares the list table items.
 	 *
 	 * @since 1.3.0
+	 * @return void
 	 */
 	public function prepare_items() {
 		$per_page = $this->get_items_per_page( 'networks_per_page' );
@@ -96,6 +97,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * Outputs the message to show when no list items are found.
 	 *
 	 * @since 1.3.0
+	 * @return void
 	 */
 	public function no_items() {
 		esc_html_e( 'No networks found.', 'wp-multi-network' );
@@ -188,6 +190,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * @since 2.3.0
 	 *
 	 * @param object $network The current network item.
+	 * @return void
 	 */
 	public function single_row( $network ) {
 		$class = (int) get_current_site()->id === (int) $network->id ? 'current' : 'not-current';
@@ -270,6 +273,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * @since 2.0.0
 	 *
 	 * @param WP_Network $network The current network object.
+	 * @return void
 	 */
 	public function column_cb( $network ) {
 
@@ -298,6 +302,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * @since 2.0.0
 	 *
 	 * @param WP_Network $network The current network object.
+	 * @return void
 	 */
 	public function column_title( $network ) {
 		$network_states = $this->get_states( $network );
@@ -340,6 +345,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * @since 2.0.0
 	 *
 	 * @param WP_Network $network The current network object.
+	 * @return void
 	 */
 	public function column_domain( $network ) {
 		echo esc_html( $network->domain );
@@ -351,6 +357,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * @since 2.0.0
 	 *
 	 * @param WP_Network $network The current network object.
+	 * @return void
 	 */
 	public function column_path( $network ) {
 		echo esc_html( $network->path );
@@ -362,6 +369,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * @since 2.0.0
 	 *
 	 * @param WP_Network $network The current network object.
+	 * @return void
 	 */
 	public function column_blogs( $network ) {
 		$sites = get_network_option( $network->id, 'blog_count' );
@@ -379,6 +387,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * @since 2.0.0
 	 *
 	 * @param WP_Network $network The current network object.
+	 * @return void
 	 */
 	public function column_admins( $network ) {
 		$network_admins = (array) get_network_option( $network->id, 'site_admins', array() );
@@ -394,6 +403,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 	 * @since 2.0.0
 	 *
 	 * @param WP_Network $network The current network object.
+	 * @return void
 	 */
 	public function column_id( $network ) {
 		echo esc_html( strval( $network->id ) );

--- a/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
@@ -100,7 +100,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|bool True if the request has read access, error object otherwise.
 	 */
@@ -113,7 +114,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
 	 */
@@ -268,7 +270,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|bool True if the request has read access for the item, error object otherwise.
 	 */
@@ -286,7 +289,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
 	 */
@@ -307,7 +311,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|bool True if the request has access to create items, error object otherwise.
 	 */
@@ -320,7 +325,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
 	 */
@@ -405,7 +411,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|bool True if the request has access to update the item, error object otherwise.
 	 */
@@ -431,7 +438,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
 	 */
@@ -489,7 +497,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|bool True if the request has access to delete the item, error object otherwise.
 	 */
@@ -507,7 +516,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Full details about the request.
+	 * @template T of WP_REST_Request
+	 * @param T $request Full details about the request.
 	 *
 	 * @return WP_Error|WP_REST_Response Response object on success, or error object on failure.
 	 */
@@ -560,8 +570,9 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_Network      $network Network object.
-	 * @param WP_REST_Request $request Request object.
+	 * @template T of WP_REST_Request
+	 * @param WP_Network $network Network object.
+	 * @param T          $request Request object.
 	 *
 	 * @return WP_REST_Response Response object.
 	 */
@@ -647,7 +658,8 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_REST_Request $request Request object.
+	 * @template T of WP_REST_Request
+	 * @param T $request Request object.
 	 *
 	 * @return array<string, string>|WP_Error Prepared network, otherwise WP_Error object.
 	 */
@@ -838,8 +850,9 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @param WP_Network      $network Network object.
-	 * @param WP_REST_Request $request Request data to check.
+	 * @template T of WP_REST_Request
+	 * @param WP_Network $network Network object.
+	 * @param T          $request Request data to check.
 	 *
 	 * @return bool Whether the network can be read.
 	 */

--- a/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
@@ -605,7 +605,7 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @param WP_Network $network Network object.
 	 *
-	 * @return array Links for the given network.
+	 * @return array<string, array<string, string>> Links for the given network.
 	 */
 	protected function prepare_links( $network ) {
 		$links = array(
@@ -649,7 +649,7 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return array|WP_Error Prepared network, otherwise WP_Error object.
+	 * @return array<string, string>|WP_Error Prepared network, otherwise WP_Error object.
 	 */
 	protected function prepare_item_for_database( $request ) {
 		$prepared_network = array();
@@ -684,7 +684,7 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	public function get_item_schema() {
 		$schema = array(
@@ -732,7 +732,7 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 *
 	 * @since 2.4.0
 	 *
-	 * @return array Networks collection parameters.
+	 * @return array<string, mixed> Networks collection parameters.
 	 */
 	public function get_collection_params() {
 		$query_params = parent::get_collection_params();

--- a/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-rest-networks-controller.php
@@ -30,6 +30,7 @@ class WP_MS_REST_Networks_Controller extends WP_REST_Controller {
 	 * Registers the routes for the objects of the controller.
 	 *
 	 * @since 2.4.0
+	 * @return void
 	 */
 	public function register_routes() {
 

--- a/wp-multi-network/includes/deprecated.php
+++ b/wp-multi-network/includes/deprecated.php
@@ -36,6 +36,7 @@ if ( ! function_exists( 'wpmn_fix_subsite_upload_path' ) ) {
 	 *
 	 * @param string $value   Upload path option value.
 	 * @param int    $blog_id Site ID.
+	 * @return string
 	 */
 	function wpmn_fix_subsite_upload_path( $value, $blog_id ) {
 		global $current_site, $wp_version;

--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -54,7 +54,7 @@ if ( ! function_exists( 'user_has_networks' ) ) :
 	 * @since 1.3.0
 	 *
 	 * @param int $user_id Optional. User ID. Default is the current user.
-	 * @return array|bool Array of network IDs, or false if none.
+	 * @return int[]|bool Array of network IDs, or false if none.
 	 */
 	function user_has_networks( $user_id = 0 ) {
 		global $wpdb;
@@ -412,7 +412,7 @@ if ( ! function_exists( 'add_network' ) ) :
 	 *
 	 * @global wpdb $wpdb WordPress database abstraction object.
 	 *
-	 * @param array $args  {
+	 * @param array<string, mixed> $args  {
 	 *     Array of network arguments.
 	 *
 	 *     @type string  $domain           Domain name for new network - for VHOST=no,
@@ -973,7 +973,7 @@ if ( ! function_exists( 'network_options_list' ) ) :
 	 *
 	 * @since 1.3.0
 	 *
-	 * @return array List of network option names.
+	 * @return string[] List of network option names.
 	 */
 	function network_options_list() {
 		$network_options = array(
@@ -998,7 +998,7 @@ if ( ! function_exists( 'network_options_to_copy' ) ) :
 	 *
 	 * @since 1.3.0
 	 *
-	 * @return array List of network $option_name => $option_label pairs.
+	 * @return array<string, string> List of network $option_name => $option_label pairs.
 	 */
 	function network_options_to_copy() {
 		$network_options = array(

--- a/wp-multi-network/includes/metaboxes/edit-network.php
+++ b/wp-multi-network/includes/metaboxes/edit-network.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.7.0
  *
  * @param WP_Network $network Optional. Network object. Default null.
+ * @return void
  */
 function wpmn_edit_network_details_metabox( $network = null ) {
 	$domain = ! empty( $network->domain ) ? Requests_IDNAEncoder::encode( $network->domain ) : '';
@@ -56,6 +57,7 @@ function wpmn_edit_network_details_metabox( $network = null ) {
  * Renders the metabox for defining the main site for a new network.
  *
  * @since 1.7.0
+ * @return void
  */
 function wpmn_edit_network_new_site_metabox() {
 	?>
@@ -85,6 +87,7 @@ function wpmn_edit_network_new_site_metabox() {
  * @since 1.7.0
  *
  * @param WP_Network $network Optional. Network object. Default null.
+ * @return void
  */
 function wpmn_edit_network_assign_sites_metabox( $network = null ) {
 	$to = get_sites(
@@ -161,6 +164,7 @@ function wpmn_edit_network_assign_sites_metabox( $network = null ) {
  * @since 1.7.0
  *
  * @param WP_Network $network Optional. Network object. Default null.
+ * @return void
  */
 function wpmn_edit_network_publish_metabox( $network = null ) {
 	if ( empty( $network ) ) {

--- a/wp-multi-network/includes/metaboxes/move-site.php
+++ b/wp-multi-network/includes/metaboxes/move-site.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.7.0
  *
  * @param WP_Site $site Optional. Site object. Default null.
+ * @return void
  */
 function wpmn_move_site_list_metabox( $site = null ) {
 
@@ -77,6 +78,7 @@ function wpmn_move_site_list_metabox( $site = null ) {
  * @since 1.7.0
  *
  * @param WP_Site $site Optional. Site object. Default null.
+ * @return void
  */
 function wpmn_move_site_assign_metabox( $site = null ) {
 	?>

--- a/wpmn-loader.php
+++ b/wpmn-loader.php
@@ -110,6 +110,7 @@ class WPMN_Loader {
 	 * Sets up constants used by the plugin if they are not already defined.
 	 *
 	 * @since 1.3.0
+	 * @return void
 	 */
 	private function constants() {
 		if ( ! defined( 'RESCUE_ORPHANED_BLOGS' ) ) {
@@ -125,6 +126,7 @@ class WPMN_Loader {
 	 * Sets up the global properties used by the plugin.
 	 *
 	 * @since 1.3.0
+	 * @return void
 	 */
 	private function setup_globals() {
 		$this->file       = __FILE__;
@@ -137,6 +139,7 @@ class WPMN_Loader {
 	 * Includes the required files to run the plugin.
 	 *
 	 * @since 1.3.0
+	 * @return void
 	 */
 	private function includes() {
 
@@ -186,6 +189,7 @@ class WPMN_Loader {
  * Hooks loader into muplugins_loaded, in order to load early.
  *
  * @since 1.3.0
+ * @return void
  */
 function setup_multi_network() { // phpcs:ignore Universal.Files.SeparateFunctionsFromOO.Mixed
 	wpmn();
@@ -196,6 +200,7 @@ add_action( 'muplugins_loaded', 'setup_multi_network' );
  * Hook REST endpoints on rest_api_init
  *
  * @since 2.3.0
+ * @return void
  */
 function setup_multi_network_endpoints() {
 	$controller = new WP_MS_REST_Networks_Controller();
@@ -209,7 +214,6 @@ add_action( 'rest_api_init', 'setup_multi_network_endpoints', 99 );
  * It will be instantiated if not available yet.
  *
  * @since 1.7.0
- *
  * @return WPMN_Loader WP Multi Network instance to use.
  */
 function wpmn() {


### PR DESCRIPTION
PHPStan level 6 focuses on enforcing type hints in PHP code. It's about adding missing type declarations and ensuring that all types are explicitly specified, including array value types and generic types.

Some minor bugs were also fixed:
- `echo esc_html_e()`
- throw new Error instead of WP_CLI::error in a command 