### PR TITLE
Upgrade composer dev packages

### DIFF
--- a/.github/workflows/php-sniffer-ci.yml
+++ b/.github/workflows/php-sniffer-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: '7.4'
           coverage: none
           tools: composer, cs2pr
 

--- a/.github/workflows/php-sniffer-ci.yml
+++ b/.github/workflows/php-sniffer-ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           php-version: '7.4'
           coverage: none
-          tools: composer, cs2pr
+          tools: composer
 
       - name: Get Composer cache directory
         id: composer-cache
@@ -41,4 +41,4 @@ jobs:
         run: composer install --prefer-dist --no-suggest --no-progress --no-interaction
 
       - name: Detect coding standard violations (PHPCS)
-        run: vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | cs2pr --graceful-warnings
+        run: composer run phpcs

--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,18 @@
     "composer/installers": "^1.0 || ^2.0"
   },
   "require-dev": {
-    "php-stubs/wp-cli-stubs": "^2.12",
-    "phpcompatibility/phpcompatibility-wp": "^2.1",
+    "php-stubs/wp-cli-stubs": "^2.12.0",
+    "phpcompatibility/phpcompatibility-wp": "^2.1.8",
     "phpstan/extension-installer": "^1.4.3",
-    "phpstan/phpstan": "^2.1.32",
+    "phpstan/phpstan": "^2.1.33",
+    "staabm/annotate-pull-request-from-checkstyle": "^1.8.6",
     "szepeviktor/phpstan-wordpress": "^2.0.3",
     "wp-coding-standards/wpcs": "^3.3.0",
     "yoast/wp-test-utils": "^1.2.0"
   },
   "scripts": {
     "phpstan": "vendor/bin/phpstan analyse --memory-limit=1G",
-    "phpcs": "vendor/bin/phpcs -ps wpmn-loader.php wp-multi-network/includes --standard=PHPCompatibilityWP --runtime-set testVersion 7.2-"
+    "phpcs": "vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 --runtime-set testVersion 7.2- | vendor/bin/cs2pr --graceful-warnings"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
   },
   "scripts": {
     "phpstan": "vendor/bin/phpstan analyse --memory-limit=1G",
-    "phpcs": "vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 --runtime-set testVersion 7.2- | vendor/bin/cs2pr --graceful-warnings"
+    "phpcs": "vendor/bin/phpcs -q --report=checkstyle --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 | vendor/bin/cs2pr --graceful-warnings"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "source": "https://github.com/stuttter/wp-multi-network"
   },
   "require": {
-    "php": ">=7.4",
+    "php": ">=7.2",
     "composer/installers": "^1.0 || ^2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require-dev": {
     "php-stubs/wp-cli-stubs": "^2.12",
-    "phpcompatibility/php-compatibility": "^9.3.5",
+    "phpcompatibility/phpcompatibility-wp": "^2.1",
     "phpstan/extension-installer": "^1.4.3",
     "phpstan/phpstan": "^2.1.32",
     "szepeviktor/phpstan-wordpress": "^2.0.3",
@@ -30,11 +30,7 @@
   },
   "scripts": {
     "phpstan": "vendor/bin/phpstan analyse --memory-limit=1G",
-    "php72": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 7.2",
-    "php74": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 7.4",
-    "php83": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.3",
-    "php84": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.4",
-    "php85": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.5"
+    "phpcs": "vendor/bin/phpcs -ps wpmn-loader.php wp-multi-network/includes --standard=PHPCompatibilityWP --runtime-set testVersion 7.2-"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "source": "https://github.com/stuttter/wp-multi-network"
   },
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.4",
     "composer/installers": "^1.0 || ^2.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,21 @@
     "composer/installers": "^1.0 || ^2.0"
   },
   "require-dev": {
-    "php-stubs/wp-cli-stubs": "^2.11",
-    "phpcompatibility/phpcompatibility-wp": "^2.1.0",
-    "phpstan/extension-installer": "^1.4",
-    "phpstan/phpstan": "^1.12",
-    "szepeviktor/phpstan-wordpress": "^1.0",
-    "wp-coding-standards/wpcs": "^3.1.0",
-    "yoast/wp-test-utils": "^1.2"
+    "php-stubs/wp-cli-stubs": "^2.12",
+    "phpcompatibility/php-compatibility": "^9.3.5",
+    "phpstan/extension-installer": "^1.4.3",
+    "phpstan/phpstan": "^2.1.32",
+    "szepeviktor/phpstan-wordpress": "^2.0.3",
+    "wp-coding-standards/wpcs": "^3.3.0",
+    "yoast/wp-test-utils": "^1.2.0"
   },
   "scripts": {
-    "phpstan": "vendor/bin/phpstan analyse --memory-limit=1G"
+    "phpstan": "vendor/bin/phpstan analyse --memory-limit=1G",
+    "php72": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 7.2",
+    "php74": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 7.4",
+    "php83": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.3",
+    "php84": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.4",
+    "php85": "vendor/bin/phpcs -p ./*.php wp-multi-network/ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --runtime-set testVersion 8.5"
   },
   "config": {
     "allow-plugins": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,4 +16,6 @@ parameters:
         - '/^Cannot access property \$ID on WP_CLI\\Fetchers\\WP_User\|false\.$/'
         # Backward compatibility with old method of passing arguments.
         - '/^Call to function is_array\(\) with array<string, mixed> will always evaluate to true\.$/'
+        # Associative CLI arguments. Passed by reference.
+        - '/^Parameter \&\$assoc_args by-ref type of method WP_MS_Network_Command::get_formatter\(\) expects array<string, mixed>, array given\.$/'
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,7 +10,6 @@ parameters:
         #- %rootDir%/../../php-stubs/wp-cli-stubs/wp-cli-tools-stubs.php
     ignoreErrors:
         - '/^Call to static method encode\(\) on an unknown class Requests_IDNAEncoder\.$/'
-        - '/^Constant WP_CONTENT_URL not found\.$/'
         # WP_Network::$blog_id is a private property that can be accessed via magic methods.
         - '/^Access to an undefined property WP_Network::\$blog_id\.$/'
         # WP_CLI\Fetchers\User::get() returns WP_User without root namespace.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,4 +13,7 @@ parameters:
         # WP_Network::$blog_id is a private property that can be accessed via magic methods.
         - '/^Access to an undefined property WP_Network::\$blog_id\.$/'
         # WP_CLI\Fetchers\User::get() returns WP_User without root namespace.
-        - '/^Access to property \$ID on an unknown class WP_CLI\\Fetchers\\WP_User\.$/'
+        - '/^Cannot access property \$ID on WP_CLI\\Fetchers\\WP_User\|false\.$/'
+        # Backward compatibility with old method of passing arguments.
+        - '/^Call to function is_array\(\) with array<string, mixed> will always evaluate to true\.$/'
+

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -1208,7 +1208,7 @@ class WP_MS_Networks_Admin {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param array<string, string> $args Optional. URL query arguments. Default empty array.
+	 * @param array<string, int|string> $args Optional. URL query arguments. Default empty array.
 	 * @return void
 	 */
 	private function handle_redirect( $args = array() ) {

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-admin.php
@@ -1221,7 +1221,7 @@ class WP_MS_Networks_Admin {
 	 *
 	 * @since 1.3.0
 	 *
-	 * @param array<string, string> $args Optional. URL query arguments. Default empty array.
+	 * @param array<string, int|string> $args Optional. URL query arguments. Default empty array.
 	 * @return string Absolute URL to the networks page.
 	 */
 	private function admin_url( $args = array() ) {

--- a/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
+++ b/wp-multi-network/includes/classes/class-wp-ms-networks-list-table.php
@@ -453,12 +453,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 
 		// Edit the network.
 		if ( current_user_can( 'edit_network', $network->id ) ) {
-			$edit_network_url = add_query_arg(
-				array(
-					'action' => 'edit_network',
-				),
-				$base_url
-			);
+			$edit_network_url = add_query_arg( array( 'action' => 'edit_network' ), $base_url );
 
 			$actions['edit'] = '<span class="edit"><a href="' . esc_url( $edit_network_url ) . '">' . esc_html__( 'Edit', 'wp-multi-network' ) . '</a></span>';
 		}
@@ -474,11 +469,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 		// Delete the network.
 		if ( $this->can_delete( $network ) ) {
 			$delete_network_url = wp_nonce_url(
-				add_query_arg(
-					array(
-						'action' => 'delete_network',
-					), $base_url
-				)
+				add_query_arg( array( 'action' => 'delete_network' ), $base_url )
 			);
 
 			$actions['delete'] = '<span class="delete"><a href="' . esc_url( $delete_network_url ) . '">' . esc_html__( 'Delete', 'wp-multi-network' ) . '</a></span>';
@@ -493,7 +484,7 @@ class WP_MS_Networks_List_Table extends WP_List_Table {
 		 * @param int    $network_id The current network ID.
 		 * @param string $network_sitename The current network name.
 		 */
-		$actions = apply_filters( 'manage_networks_action_links', array_filter( $actions ), $network->id, $network->site_name );
+		$actions = apply_filters( 'manage_networks_action_links', $actions, $network->id, $network->site_name );
 
 		// Return all row actions.
 		return $this->row_actions( $actions );

--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -612,7 +612,7 @@ if ( ! function_exists( 'add_network' ) ) :
 			// so we have to replace the hostname the hard way.
 			$current_siteurl = get_option( 'siteurl' );
 			$new_siteurl     = untrailingslashit( get_blogaddress_by_id( $new_blog_id ) );
-			$upload_url      = str_replace( $current_siteurl, $new_siteurl, WP_CONTENT_URL );
+			$upload_url      = str_replace( $current_siteurl, $new_siteurl, content_url() );
 			$upload_url      = $upload_url . '/uploads';
 
 			$upload_dir = WP_CONTENT_DIR;

--- a/wp-multi-network/includes/functions.php
+++ b/wp-multi-network/includes/functions.php
@@ -842,15 +842,13 @@ if ( ! function_exists( 'delete_network' ) ) :
 				return new WP_Error( 'network_not_empty', __( 'Cannot delete network with sites.', 'wp-multi-network' ) );
 			}
 
-			if ( true === $delete_blogs ) {
-				foreach ( $sites as $site ) {
-					if ( wp_should_rescue_orphaned_sites() ) {
-						move_site( $site->id, 0 );
-						continue;
-					}
-
-					wpmu_delete_blog( $site->id, true );
+			foreach ( $sites as $site ) {
+				if ( wp_should_rescue_orphaned_sites() ) {
+					move_site( $site->id, 0 );
+					continue;
 				}
+
+				wpmu_delete_blog( $site->id, true );
 			}
 		}
 


### PR DESCRIPTION
This PR updates the development tooling stack, addresses related compatibility issues that arise from those upgrades, and introduces PHPCompatibility checks tailored to WordPress’ requirements. While the plugin’s minimum PHP requirement of 7.2 remains unchanged, the PHPCS workflow now runs on PHP 7.4 to allow the use of the latest development tooling packages.